### PR TITLE
[Row Controller] RP2350 pin mapping

### DIFF
--- a/src/row/src/main.cpp
+++ b/src/row/src/main.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include "rp2350/pins.h"
 
 void setup() {
     Serial.begin(115200);

--- a/src/row/src/native/README
+++ b/src/row/src/native/README
@@ -1,0 +1,4 @@
+Host-side (macOS/Linux) mock implementations of the common interfaces
+(e.g. IStatusLed, IPowerMonitor), built under env:native so shared
+protocol/logic code can be compiled and unit-tested without RP2350
+hardware. Mirrors src/tile/DF2-Tile/src/native/.

--- a/src/row/src/rp2350/pins.h
+++ b/src/row/src/rp2350/pins.h
@@ -1,0 +1,28 @@
+#pragma once
+// Pin assignments for the Seeed Xiao RP2350 row controller board.
+// These are tentative values from the issue spec — verify against
+// pcb/row-controller/ KiCad schematic before flashing hardware.
+
+// Status LEDs — active-low (pin sinks current to light the LED)
+#define PIN_LED_READY  D0
+#define PIN_LED_DATA   D1
+
+// RS-485 direction control (THVD1420DR DE/RE)
+// LOW = RX (default), HIGH = TX
+#define PIN_PI_XDIR    D2   // Row Bus (Pi-facing) transceiver
+#define PIN_ROW_XDIR   D3   // Tile Bus (row-facing) transceiver
+
+// I2C — INA220BIDGSR power monitor (default Wire/I2C0 pins on this board)
+#define PIN_SDA        D4
+#define PIN_SCL        D5
+
+// Tile Bus UART (row controller is bus master)
+#define PIN_ROW_TX     D6
+#define PIN_ROW_RX     D7
+
+// Tile Bus SENSE line (row controller runs SENSE auto-mapping)
+#define PIN_ROW_SENSE  D8
+
+// Row Bus UART (upstream to Raspberry Pi)
+#define PIN_PI_RX      D9
+#define PIN_PI_TX      D10


### PR DESCRIPTION
## Summary
- Adds `src/row/src/rp2350/pins.h` with the RP2350 GPIO pin assignments from #21 (status LEDs, both RS-485 direction pins, I2C, Tile Bus UART/SENSE, Row Bus UART)
- Adds `src/row/src/native/` as the mock-implementation directory, establishing the common/platform split (`rp2350/` + `native/`) that mirrors `src/tile/DF2-Tile/`'s `at/` + `native/` layout, ahead of #22 and #23
- `src/main.cpp` now includes `rp2350/pins.h`

No driver logic in this PR — just the pin constants, per #21's scope.

## Test plan
- [x] `pio run -e seeed_xiao_rp2350` builds clean
- [x] `pio run -e native` builds clean
- [x] `rp2350/` excluded from `env:native`, `native/` excluded from `env:seeed_xiao_rp2350` (per `platformio.ini` src filters)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)