### PR TITLE
[Row Controller] INA220 power monitor driver + test program

### DIFF
--- a/src/row/include/power_monitor.h
+++ b/src/row/include/power_monitor.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <cstdint>
+
+struct PowerReading {
+    uint16_t voltage_mV;
+    uint16_t current_mA;
+    uint16_t power_mW;
+};
+
+class IPowerMonitor {
+public:
+    virtual void init() = 0;
+    virtual PowerReading read() = 0;
+};

--- a/src/row/platformio.ini
+++ b/src/row/platformio.ini
@@ -30,3 +30,9 @@ platform  = https://github.com/Seeed-Studio/platform-seeedboards.git
 board     = seeed-xiao-rp2350
 framework = arduino
 build_src_filter = -<*> +<hw_tests/main_led_test.cpp> +<rp2350/status_led_rp2350.cpp>
+
+[env:seeed_xiao_rp2350_power_test]
+platform  = https://github.com/Seeed-Studio/platform-seeedboards.git
+board     = seeed-xiao-rp2350
+framework = arduino
+build_src_filter = -<*> +<hw_tests/main_power_test.cpp> +<rp2350/power_monitor_rp2350.cpp>

--- a/src/row/src/hw_tests/main_power_test.cpp
+++ b/src/row/src/hw_tests/main_power_test.cpp
@@ -1,0 +1,24 @@
+#include <Arduino.h>
+#include "rp2350/power_monitor_rp2350.h"
+
+// Standalone INA220 connectivity test — polls the power monitor once a
+// second and prints readings to Serial.
+
+static PowerMonitorRP2350 power_monitor;
+
+void setup() {
+    Serial.begin(115200);
+    power_monitor.init();
+}
+
+void loop() {
+    PowerReading r = power_monitor.read();
+    Serial.print("voltage=");
+    Serial.print(r.voltage_mV);
+    Serial.print("mV current=");
+    Serial.print(r.current_mA);
+    Serial.print("mA power=");
+    Serial.print(r.power_mW);
+    Serial.println("mW");
+    delay(1000);
+}

--- a/src/row/src/native/power_monitor_native.cpp
+++ b/src/row/src/native/power_monitor_native.cpp
@@ -1,0 +1,23 @@
+#include "power_monitor_native.h"
+#include <cmath>
+#include <cstdio>
+
+void PowerMonitorNative::init() {
+    printf("[power] monitor ready (native/mock mode)\n");
+    fflush(stdout);
+}
+
+PowerReading PowerMonitorNative::read() {
+    ++tick;
+
+    // Plausible 12V-rail reading with current riding a slow sine wave,
+    // so common code polling this can exercise changing load without hardware.
+    float current_a = 2.0f + 1.5f * sinf((float)tick * 0.1f);
+    float voltage_v = 12.0f;
+
+    PowerReading r;
+    r.voltage_mV = (uint16_t)(voltage_v * 1000.0f);
+    r.current_mA = (uint16_t)(current_a * 1000.0f);
+    r.power_mW   = (uint16_t)(voltage_v * current_a * 1000.0f);
+    return r;
+}

--- a/src/row/src/native/power_monitor_native.h
+++ b/src/row/src/native/power_monitor_native.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "power_monitor.h"
+#include <cstdint>
+
+class PowerMonitorNative : public IPowerMonitor {
+    uint32_t tick = 0;
+public:
+    void init() override;
+    PowerReading read() override;
+};

--- a/src/row/src/rp2350/power_monitor_rp2350.cpp
+++ b/src/row/src/rp2350/power_monitor_rp2350.cpp
@@ -1,0 +1,74 @@
+#include <Arduino.h>
+#include <Wire.h>
+#include "power_monitor_rp2350.h"
+
+// INA220BIDGSR power monitor. Register map, calibration formula, and bus
+// voltage decoding are identical to the INA219's (TI datasheet §8.5,
+// §8.6.3.2). Verified against Adafruit_INA219's reference implementation.
+//
+// A0 and A1 both tied to Vs -> I2C address 0x45 (datasheet Table 2).
+static constexpr uint8_t INA220_ADDR = 0x45;
+
+static constexpr uint8_t REG_CONFIG      = 0x00;
+static constexpr uint8_t REG_BUS_V       = 0x02;
+static constexpr uint8_t REG_POWER       = 0x03;
+static constexpr uint8_t REG_CURRENT     = 0x04;
+static constexpr uint8_t REG_CALIBRATION = 0x05;
+
+// BRNG=32V, PGA=/8 (+-320mV shunt range), BADC/SADC=12-bit, continuous
+// shunt+bus conversion. This is the chip's power-on-reset default
+// (0x399F) and comfortably covers our ~25 mV max shunt swing (see below).
+static constexpr uint16_t CONFIG_VALUE = 0x399F;
+
+// 5 mOhm shunt on the row's 12V rail (docs/power.md); row current peaks
+// ~4A at full white. Calibrate for 5A of headroom rather than that
+// measured max, per the issue's guidance.
+static constexpr float R_SHUNT_OHMS           = 0.005f;
+static constexpr float MAX_EXPECTED_CURRENT_A = 5.0f;
+// Current_LSB = Max_Expected_Current / 2^15, rounded up to a round number.
+static constexpr float CURRENT_LSB_MA = 0.2f;
+static constexpr float POWER_LSB_MW   = 20.0f * CURRENT_LSB_MA;
+// Calibration = trunc(0.04096 / (Current_LSB[A] * R_SHUNT)).
+static constexpr uint16_t CALIBRATION_VALUE =
+    (uint16_t)(0.04096f / ((CURRENT_LSB_MA / 1000.0f) * R_SHUNT_OHMS));
+
+static void write_reg(uint8_t reg, uint16_t value) {
+    Wire.beginTransmission(INA220_ADDR);
+    Wire.write(reg);
+    Wire.write((uint8_t)(value >> 8));
+    Wire.write((uint8_t)(value & 0xFF));
+    Wire.endTransmission();
+}
+
+static uint16_t read_reg(uint8_t reg) {
+    Wire.beginTransmission(INA220_ADDR);
+    Wire.write(reg);
+    Wire.endTransmission(false);  // repeated start, keep the bus held
+    Wire.requestFrom((uint8_t)INA220_ADDR, (uint8_t)2);
+    uint16_t hi = Wire.read();
+    uint16_t lo = Wire.read();
+    return (uint16_t)((hi << 8) | lo);
+}
+
+void PowerMonitorRP2350::init() {
+    Wire.begin();
+    write_reg(REG_CONFIG, CONFIG_VALUE);
+    write_reg(REG_CALIBRATION, CALIBRATION_VALUE);
+}
+
+PowerReading PowerMonitorRP2350::read() {
+    // The calibration register is known to reset to 0 under electrical
+    // noise on INA219-family parts; rewrite it before every current/power
+    // read rather than trusting it survived since init().
+    write_reg(REG_CALIBRATION, CALIBRATION_VALUE);
+
+    uint16_t bus_raw     = read_reg(REG_BUS_V);
+    int16_t  current_raw = (int16_t)read_reg(REG_CURRENT);
+    uint16_t power_raw   = read_reg(REG_POWER);
+
+    PowerReading r;
+    r.voltage_mV = (uint16_t)((bus_raw >> 3) * 4);
+    r.current_mA = (uint16_t)((current_raw < 0 ? 0 : current_raw) * CURRENT_LSB_MA);
+    r.power_mW   = (uint16_t)(power_raw * POWER_LSB_MW);
+    return r;
+}

--- a/src/row/src/rp2350/power_monitor_rp2350.h
+++ b/src/row/src/rp2350/power_monitor_rp2350.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "power_monitor.h"
+
+class PowerMonitorRP2350 : public IPowerMonitor {
+public:
+    void init() override;
+    PowerReading read() override;
+};


### PR DESCRIPTION
## Summary
- Adds `IPowerMonitor`/`PowerReading` (`include/power_monitor.h`, unchanged from #23's spec) and a `PowerMonitorRP2350` driver (`src/rp2350/power_monitor_rp2350.{h,cpp}`) for the INA220BIDGSR
- I2C address **0x45** (both A0/A1 tied to Vs, per your resolution on #23)
- Register map, bus-voltage decoding, and calibration formula are identical to the INA219's — verified the bit-shift (`(raw >> 3) * 4` for bus voltage in mV) and calibration math (`0.04096 / (Current_LSB * R_shunt)`) against Adafruit_INA219's reference implementation rather than trusting it from memory
- Calibrated for **5A headroom** over the ~4A/row peak noted in `docs/power.md` (`Current_LSB = 0.2 mA/bit`, `Calibration = 40960`)
- Calibration register is rewritten before every `read()` — INA219-family parts are known to reset it to 0 under electrical noise, so this avoids current/power silently sticking at 0
- Adds `PowerMonitorNative` (`src/native/power_monitor_native.{h,cpp}`), a sine-wave mock so `env:native` can exercise common code without hardware
- Adds `src/hw_tests/main_power_test.cpp` + a new `env:seeed_xiao_rp2350_power_test` env, polling once/sec and printing `voltage=...mV current=...mA power=...mW` to `Serial`

## Test plan
- [x] `pio run -e seeed_xiao_rp2350` builds clean
- [x] `pio run -e seeed_xiao_rp2350_power_test` builds clean
- [x] `pio run -e native` builds clean
- [x] Compiled and ran `power_monitor_native.cpp` standalone with `-Wall -Wextra`: no warnings, produces plausible values (12000mV, current riding 2-3.5A)
- [x] Flash `seeed_xiao_rp2350_power_test` to hardware and confirm plausible readings (12V rail, current rising under LED load)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)