### PR TITLE
[Row Controller] TileMap: slot -> tile address/status/retry data structure

### DIFF
--- a/src/row/lib/row_core/tile_map.h
+++ b/src/row/lib/row_core/tile_map.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <stdint.h>
+
+// Wire-compatible with docs/row-bus-protocol.md's STATUS_RESP tile_status[] values.
+enum class TileStatus : uint8_t {
+    NOT_DISCOVERED = 0x00,
+    OK             = 0x01,
+    NON_RESPONSIVE = 0x02,
+    TEST_FAILED    = 0x03,
+};
+
+struct TileSlot {
+    bool       discovered  = false;
+    uint8_t    address     = 0;
+    uint8_t    retry_count = 0;
+    TileStatus status      = TileStatus::NOT_DISCOVERED;
+};
+
+// Slot (0..7) -> discovered tile address/status/retry-count, one TileSlot per
+// logical position. Array-of-structs so "everything about slot N" is a single
+// index, not several parallel array lookups.
+class TileMap {
+public:
+    static constexpr uint8_t NUM_SLOTS = 8;
+
+    void reset() {
+        for (uint8_t i = 0; i < NUM_SLOTS; i++) slots_[i] = TileSlot{};
+    }
+
+    void set_discovered(uint8_t slot, uint8_t address) {
+        slots_[slot].discovered = true;
+        slots_[slot].address    = address;
+        slots_[slot].status     = TileStatus::OK;
+    }
+
+    void set_status(uint8_t slot, TileStatus status) {
+        slots_[slot].status = status;
+    }
+
+    void increment_retry(uint8_t slot) {
+        slots_[slot].retry_count++;
+    }
+
+    bool is_discovered(uint8_t slot) const { return slots_[slot].discovered; }
+    uint8_t address_for(uint8_t slot) const { return slots_[slot].address; }
+    uint8_t retry_count(uint8_t slot) const { return slots_[slot].retry_count; }
+    TileStatus status_for(uint8_t slot) const { return slots_[slot].status; }
+
+    uint8_t discovered_count() const {
+        uint8_t count = 0;
+        for (uint8_t i = 0; i < NUM_SLOTS; i++)
+            if (slots_[i].discovered) count++;
+        return count;
+    }
+
+private:
+    TileSlot slots_[NUM_SLOTS] = {};
+};

--- a/src/row/test/test_tile_map/test_tile_map.cpp
+++ b/src/row/test/test_tile_map/test_tile_map.cpp
@@ -1,0 +1,70 @@
+#include <unity.h>
+#include "tile_map.h"
+
+void setUp() {}
+void tearDown() {}
+
+void test_reset_clears_all_slots() {
+    TileMap map;
+    map.reset();
+    for (uint8_t i = 0; i < TileMap::NUM_SLOTS; i++)
+        TEST_ASSERT_FALSE(map.is_discovered(i));
+    TEST_ASSERT_EQUAL(0, map.discovered_count());
+}
+
+void test_set_discovered_populates_slot() {
+    TileMap map;
+    map.reset();
+    map.set_discovered(3, 0x07);
+
+    TEST_ASSERT_TRUE(map.is_discovered(3));
+    TEST_ASSERT_EQUAL_HEX8(0x07, map.address_for(3));
+    TEST_ASSERT_EQUAL(TileStatus::OK, map.status_for(3));
+    TEST_ASSERT_EQUAL(1, map.discovered_count());
+}
+
+void test_retry_count_is_per_slot() {
+    TileMap map;
+    map.reset();
+    map.increment_retry(3);
+    map.increment_retry(3);
+    map.increment_retry(3);
+
+    TEST_ASSERT_EQUAL(3, map.retry_count(3));
+    TEST_ASSERT_EQUAL(0, map.retry_count(4)); // untouched, confirms per-slot isolation
+}
+
+void test_set_status_does_not_affect_address_or_retry_count() {
+    TileMap map;
+    map.reset();
+    map.set_discovered(3, 0x07);
+    map.increment_retry(3);
+
+    map.set_status(3, TileStatus::NON_RESPONSIVE);
+
+    TEST_ASSERT_EQUAL(TileStatus::NON_RESPONSIVE, map.status_for(3));
+    TEST_ASSERT_EQUAL_HEX8(0x07, map.address_for(3));
+    TEST_ASSERT_EQUAL(1, map.retry_count(3));
+}
+
+void test_discovered_count_counts_only_discovered_slots() {
+    TileMap map;
+    map.reset();
+    map.set_discovered(0, 0x01);
+    map.set_discovered(1, 0x02);
+    map.set_discovered(5, 0x06);
+
+    TEST_ASSERT_EQUAL(3, map.discovered_count());
+}
+
+int main(int, char **) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_reset_clears_all_slots);
+    RUN_TEST(test_set_discovered_populates_slot);
+    RUN_TEST(test_retry_count_is_per_slot);
+    RUN_TEST(test_set_status_does_not_affect_address_or_retry_count);
+    RUN_TEST(test_discovered_count_counts_only_discovered_slots);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Adds `src/row/lib/row_core/tile_map.h`: `TileMap`, an array of `TileSlot{discovered, address, retry_count, status}` indexed by logical slot (0-7)
- `TileStatus` values are wire-compatible with `docs/row-bus-protocol.md`'s `STATUS_RESP.tile_status[]` bytes (`0x00`-`0x03`) — no translation needed downstream
- Retry counts are tracked **per slot**, not as a single run-wide counter — a flaky physical position can be told apart from a solid one
- Header-only: every method is a one-line index into `slots_`, no `.cpp` needed

## Test plan
- [x] `pio test -e native` — 5/5 new Unity tests pass, covering every acceptance criterion in #37 (reset, set_discovered, per-slot retry isolation, set_status not affecting address/retry, discovered_count)
- [x] `pio run` for all four row-project envs (`seeed_xiao_rp2350`, `seeed_xiao_rp2350_led_test`, `seeed_xiao_rp2350_power_test`, `native`) — unaffected, since nothing consumes `TileMap` yet (that's #29)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)