### PR TITLE
[Row Controller] SenseMapper: Tile Bus SENSE auto-mapping state machine

### DIFF
--- a/src/row/include/row_sense_control.h
+++ b/src/row/include/row_sense_control.h
@@ -1,0 +1,8 @@
+#pragma once
+
+class IRowSenseControl {
+public:
+    virtual ~IRowSenseControl() = default;
+    virtual void assert_out() = 0;    // drive SENSE toward slot 0 low
+    virtual void release_out() = 0;   // release (high-Z)
+};

--- a/src/row/lib/row_core/sense_mapper.cpp
+++ b/src/row/lib/row_core/sense_mapper.cpp
@@ -1,0 +1,135 @@
+#include "sense_mapper.h"
+
+SenseMapper::SenseMapper(ITransport &transport, IRowSenseControl &sense, TileMap &map)
+    : transport_(transport), sense_(sense), map_(map) {}
+
+void SenseMapper::send_detect_sense() {
+    Frame f{};
+    f.addr = ADDR_BROADCAST;
+    f.cmd  = (uint8_t)Cmd::DETECT_SENSE;
+    f.len  = 0;
+    transport_.send(f);
+}
+
+void SenseMapper::send_activate_sense(uint8_t addr) {
+    Frame f{};
+    f.addr = addr;
+    f.cmd  = (uint8_t)Cmd::ACTIVATE_SENSE;
+    f.len  = 0;
+    transport_.send(f);
+}
+
+void SenseMapper::send_clear_sense(uint8_t addr) {
+    Frame f{};
+    f.addr = addr;
+    f.cmd  = (uint8_t)Cmd::CLEAR_SENSE;
+    f.len  = 0;
+    transport_.send(f);
+}
+
+void SenseMapper::broadcast_clear_sense() {
+    Frame f{};
+    f.addr = ADDR_BROADCAST;
+    f.cmd  = (uint8_t)Cmd::CLEAR_SENSE;
+    f.len  = 0;
+    transport_.send(f);
+}
+
+void SenseMapper::start() {
+    map_.reset();
+    current_slot_ = 0;
+    state_ = SenseMapState::DISCOVERING;
+    step_  = Step::START;
+}
+
+void SenseMapper::finish_discovery() {
+    // The last discovered tile's own outgoing SENSE is still asserted
+    // (activated to reach the now-missing next slot) - release everything.
+    broadcast_clear_sense();
+    state_ = SenseMapState::DONE;
+}
+
+void SenseMapper::fail_discovery() {
+    broadcast_clear_sense();
+    state_ = SenseMapState::ERROR;
+}
+
+void SenseMapper::advance_to_next_slot(uint32_t now_ms) {
+    // Release whatever is currently driving this slot's SENSE-in so it
+    // stops answering DETECT_SENSE once we move on to the next slot.
+    if (current_slot_ == 0) {
+        sense_.release_out();
+    } else {
+        send_clear_sense(map_.address_for(current_slot_ - 1));
+    }
+
+    current_slot_++;
+    if (current_slot_ >= TileMap::NUM_SLOTS) {
+        finish_discovery();
+        return;
+    }
+
+    send_detect_sense();
+    request_sent_ms_ = now_ms;
+    step_ = Step::WAIT_DETECT_RESP;
+}
+
+void SenseMapper::poll(uint32_t now_ms) {
+    if (state_ != SenseMapState::DISCOVERING) return;
+
+    switch (step_) {
+
+    case Step::START:
+        sense_.assert_out();
+        send_detect_sense();
+        request_sent_ms_ = now_ms;
+        step_ = Step::WAIT_DETECT_RESP;
+        break;
+
+    case Step::WAIT_DETECT_RESP: {
+        Frame f;
+        if (transport_.poll(parser_, &f)) {
+            if (f.cmd == (uint8_t)Cmd::DETECT_RESP) {
+                map_.set_discovered(current_slot_, f.addr);
+                send_activate_sense(f.addr);
+                request_sent_ms_ = now_ms;
+                step_ = Step::WAIT_ACTIVATE_ACK;
+            }
+            // else: unrelated frame, ignore and keep waiting.
+        } else if (now_ms - request_sent_ms_ >= TIMEOUT_MS) {
+            map_.increment_retry(current_slot_);
+            if (map_.retry_count(current_slot_) > MAX_RETRIES) {
+                // No tile answered after the full retry budget - this is the
+                // expected end-of-chain signal, not a failure.
+                finish_discovery();
+            } else {
+                send_detect_sense();
+                request_sent_ms_ = now_ms;
+            }
+        }
+        break;
+    }
+
+    case Step::WAIT_ACTIVATE_ACK: {
+        Frame f;
+        static constexpr uint8_t ACTIVATE_ACK = (uint8_t)Cmd::ACK | (uint8_t)Cmd::ACTIVATE_SENSE;
+        if (transport_.poll(parser_, &f)) {
+            if (f.cmd == ACTIVATE_ACK && f.addr == map_.address_for(current_slot_)) {
+                advance_to_next_slot(now_ms);
+            }
+            // else: unrelated frame, ignore and keep waiting.
+        } else if (now_ms - request_sent_ms_ >= TIMEOUT_MS) {
+            map_.increment_retry(current_slot_);
+            if (map_.retry_count(current_slot_) > MAX_RETRIES) {
+                // A tile we already discovered failed to ACK a direct
+                // command - that's a real fault, not end-of-chain.
+                fail_discovery();
+            } else {
+                send_activate_sense(map_.address_for(current_slot_));
+                request_sent_ms_ = now_ms;
+            }
+        }
+        break;
+    }
+    }
+}

--- a/src/row/lib/row_core/sense_mapper.h
+++ b/src/row/lib/row_core/sense_mapper.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <stdint.h>
+#include "protocol.h"   // src/common/tile_bus_protocol/, via lib_extra_dirs
+#include "transport.h"  // src/common/tile_bus_protocol/, via lib_extra_dirs
+#include "../../include/row_sense_control.h"
+#include "tile_map.h"
+
+enum class SenseMapState : uint8_t { IDLE, DISCOVERING, DONE, ERROR };
+
+// Drives the Tile Bus SENSE auto-mapping sequence (docs/communication.md,
+// docs/tile-bus-protocol.md §9) to discover which physical tile address sits
+// at each of the 8 logical slots, populating a caller-owned TileMap.
+class SenseMapper {
+public:
+    SenseMapper(ITransport &transport, IRowSenseControl &sense, TileMap &map);
+
+    void start();                 // begin/restart discovery — calls map_.reset()
+    void poll(uint32_t now_ms);   // drive the state machine; call every loop iteration
+    SenseMapState state() const { return state_; }
+    const TileMap &result() const { return map_; }
+
+private:
+    enum class Step : uint8_t { START, WAIT_DETECT_RESP, WAIT_ACTIVATE_ACK };
+
+    // 3 total attempts per docs/tile-bus-protocol.md §7 (1 initial + 2 retries).
+    static constexpr uint8_t  MAX_RETRIES = 2;
+    // 5ms placeholder per docs/tile-bus-protocol.md §7's "Response timeout
+    // value: 5ms is a placeholder" note.
+    static constexpr uint32_t TIMEOUT_MS  = 5;
+
+    void send_detect_sense();
+    void send_activate_sense(uint8_t addr);
+    void send_clear_sense(uint8_t addr);
+    void broadcast_clear_sense();
+    void advance_to_next_slot(uint32_t now_ms);
+    void finish_discovery();
+    void fail_discovery();
+
+    ITransport       &transport_;
+    IRowSenseControl &sense_;
+    TileMap          &map_;
+    FrameParser      parser_;
+    SenseMapState    state_         = SenseMapState::IDLE;
+    Step             step_          = Step::START;
+    uint8_t          current_slot_  = 0;
+    uint32_t         request_sent_ms_ = 0;
+};

--- a/src/row/test/test_sense_mapper/test_sense_mapper.cpp
+++ b/src/row/test/test_sense_mapper/test_sense_mapper.cpp
@@ -1,0 +1,182 @@
+#include <unity.h>
+#include "sense_mapper.h"
+
+void setUp() {}
+void tearDown() {}
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+// Models a chain of `tile_count` tiles addressed 1..tile_count, one slot at a
+// time becoming "active" (visible to DETECT_SENSE) as each prior tile is
+// successfully ACTIVATE_SENSE'd, mirroring the real SENSE hardware chain
+// closely enough to drive SenseMapper's state machine and timing.
+class FakeChainTransport : public ITransport {
+public:
+    explicit FakeChainTransport(uint8_t tile_count) : tile_count_(tile_count) {}
+
+    void init() override {}
+
+    void send(const Frame &frame) override {
+        Cmd cmd = (Cmd)frame.cmd;
+
+        if (cmd == Cmd::DETECT_SENSE) {
+            if (active_slot_ >= tile_count_) {
+                pending_ = false; // no tile at this slot - real hardware silence
+                return;
+            }
+            if (fail_detect_slot_ == active_slot_ && !detect_failed_once_) {
+                detect_failed_once_ = true;
+                pending_ = false; // simulate one dropped response
+                return;
+            }
+            pending_frame_ = Frame{};
+            pending_frame_.addr = tile_address(active_slot_);
+            pending_frame_.cmd  = (uint8_t)Cmd::DETECT_RESP;
+            pending_frame_.len  = 0;
+            pending_ = true;
+
+        } else if (cmd == Cmd::ACTIVATE_SENSE) {
+            if (never_ack_activate_ || frame.addr != tile_address(active_slot_)) {
+                pending_ = false;
+                return;
+            }
+            pending_frame_ = Frame{};
+            pending_frame_.addr       = frame.addr;
+            pending_frame_.cmd        = (uint8_t)Cmd::ACK | (uint8_t)Cmd::ACTIVATE_SENSE;
+            pending_frame_.len        = 1;
+            pending_frame_.payload[0] = 0x00;
+            pending_ = true;
+            active_slot_++; // this tile now asserts its own SENSE-out
+
+        } else {
+            pending_ = false; // CLEAR_SENSE etc: no response expected
+        }
+    }
+
+    bool poll(FrameParser &, Frame *out) override {
+        if (!pending_) return false;
+        *out = pending_frame_;
+        pending_ = false;
+        return true;
+    }
+
+    void fail_first_detect_for_slot(uint8_t slot) { fail_detect_slot_ = slot; }
+    void never_ack_activate() { never_ack_activate_ = true; }
+
+private:
+    static uint8_t tile_address(uint8_t slot) { return (uint8_t)(slot + 1); }
+
+    uint8_t tile_count_;
+    uint8_t active_slot_ = 0;
+    bool    pending_ = false;
+    Frame   pending_frame_{};
+
+    int     fail_detect_slot_ = -1;
+    bool    detect_failed_once_ = false;
+    bool    never_ack_activate_ = false;
+};
+
+class FakeRowSense : public IRowSenseControl {
+public:
+    void assert_out() override { asserted = true; assert_count++; }
+    void release_out() override { asserted = false; release_count++; }
+    bool asserted = false;
+    int  assert_count = 0;
+    int  release_count = 0;
+};
+
+// Drives poll() with an advancing clock until DONE/ERROR or a safety cap.
+static void run_to_completion(SenseMapper &mapper, uint32_t &now) {
+    for (int i = 0; i < 2000 && mapper.state() == SenseMapState::DISCOVERING; i++) {
+        mapper.poll(now);
+        now += 1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void test_full_discovery_8_tiles() {
+    FakeChainTransport transport(8);
+    FakeRowSense sense;
+    TileMap map;
+    SenseMapper mapper(transport, sense, map);
+
+    mapper.start();
+    uint32_t now = 0;
+    run_to_completion(mapper, now);
+
+    TEST_ASSERT_EQUAL(SenseMapState::DONE, mapper.state());
+    TEST_ASSERT_EQUAL(8, map.discovered_count());
+    for (uint8_t i = 0; i < 8; i++) {
+        TEST_ASSERT_TRUE(map.is_discovered(i));
+        TEST_ASSERT_EQUAL_HEX8(i + 1, map.address_for(i));
+    }
+    TEST_ASSERT_TRUE(sense.assert_count >= 1);
+    TEST_ASSERT_TRUE(sense.release_count >= 1);
+}
+
+void test_short_chain_ends_via_timeout_not_error() {
+    FakeChainTransport transport(3);
+    FakeRowSense sense;
+    TileMap map;
+    SenseMapper mapper(transport, sense, map);
+
+    mapper.start();
+    uint32_t now = 0;
+    run_to_completion(mapper, now);
+
+    TEST_ASSERT_EQUAL(SenseMapState::DONE, mapper.state());
+    TEST_ASSERT_EQUAL(3, map.discovered_count());
+    TEST_ASSERT_EQUAL_HEX8(1, map.address_for(0));
+    TEST_ASSERT_EQUAL_HEX8(2, map.address_for(1));
+    TEST_ASSERT_EQUAL_HEX8(3, map.address_for(2));
+}
+
+void test_activate_sense_never_acked_reaches_error() {
+    FakeChainTransport transport(8);
+    transport.never_ack_activate();
+    FakeRowSense sense;
+    TileMap map;
+    SenseMapper mapper(transport, sense, map);
+
+    mapper.start();
+    uint32_t now = 0;
+    run_to_completion(mapper, now);
+
+    TEST_ASSERT_EQUAL(SenseMapState::ERROR, mapper.state());
+}
+
+void test_retry_is_tracked_per_slot() {
+    FakeChainTransport transport(8);
+    transport.fail_first_detect_for_slot(3);
+    FakeRowSense sense;
+    TileMap map;
+    SenseMapper mapper(transport, sense, map);
+
+    mapper.start();
+    uint32_t now = 0;
+    run_to_completion(mapper, now);
+
+    TEST_ASSERT_EQUAL(SenseMapState::DONE, mapper.state());
+    TEST_ASSERT_EQUAL(8, map.discovered_count());
+    TEST_ASSERT_EQUAL(1, map.retry_count(3));
+    for (uint8_t i = 0; i < 8; i++) {
+        if (i == 3) continue;
+        TEST_ASSERT_EQUAL(0, map.retry_count(i));
+    }
+}
+
+int main(int, char **) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_full_discovery_8_tiles);
+    RUN_TEST(test_short_chain_ends_via_timeout_not_error);
+    RUN_TEST(test_activate_sense_never_acked_reaches_error);
+    RUN_TEST(test_retry_is_tracked_per_slot);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Adds `include/row_sense_control.h` (`IRowSenseControl` — the row controller's single outgoing SENSE line toward slot 0, no sense-in to read)
- Adds `lib/row_core/sense_mapper.{h,cpp}`: `SenseMapper`, a non-blocking state machine driven by an explicit `now_ms` clock (so it's identically testable under `env:native` and drivable from `millis()` on the RP2350) implementing the discovery sequence from `docs/communication.md`/`docs/tile-bus-protocol.md` §9:
  - assert SENSE -> `DETECT_SENSE` -> `ACTIVATE_SENSE` -> release upstream -> repeat -> `DETECT_SENSE` timeout signals end-of-chain
  - populates a **caller-owned** `TileMap` (#37) rather than owning its own copy of the mapping data
  - retries tracked **per slot** on the map itself (`increment_retry`/`retry_count`), not a separate run-wide counter
  - a `DETECT_SENSE` timeout after the retry budget is the **expected** end-of-chain signal (not an error); an `ACTIVATE_SENSE` timeout on an already-discovered tile is a **real fault** (`state() -> ERROR`)
- Adds `test/test_sense_mapper/test_sense_mapper.cpp` with a `FakeChainTransport` that models a chain of N tiles closely enough to drive the real timing/retry logic, covering all 4 of #29's acceptance criteria

## Test plan
- [x] `pio test -e native` — 4/4 new tests pass: full 8-tile discovery matches `test_sense_mapping.py`'s expected mapping, a 3-tile chain ends via timeout with `state() == DONE` (not an error), an `ACTIVATE_SENSE` that's never ACKed reaches `state() == ERROR`, and a transport that drops only slot 3's first `DETECT_SENSE` produces `retry_count(3) == 1` with every other slot's `retry_count() == 0`
- [x] `pio run` for all four row-project envs — unaffected (nothing in `src/` consumes `SenseMapper` yet; that's #30)

One implementation note: `lib/row_core/sense_mapper.h` needed a relative include to reach `include/row_sense_control.h` — same PlatformIO LDF limitation (a `lib/` folder's own compile step doesn't get other directories' include paths propagated to it) already hit extracting the shared `tile_bus_protocol` library in #35.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)