### PR TITLE
[Row Controller] Native: Tile Bus mock transport (tile-bus-broker client)

### DIFF
--- a/src/row/lib/row_core/sense_mapper.cpp
+++ b/src/row/lib/row_core/sense_mapper.cpp
@@ -69,9 +69,8 @@ void SenseMapper::advance_to_next_slot(uint32_t now_ms) {
         return;
     }
 
-    send_detect_sense();
+    step_ = Step::SETTLE;
     request_sent_ms_ = now_ms;
-    step_ = Step::WAIT_DETECT_RESP;
 }
 
 void SenseMapper::poll(uint32_t now_ms) {
@@ -81,9 +80,16 @@ void SenseMapper::poll(uint32_t now_ms) {
 
     case Step::START:
         sense_.assert_out();
-        send_detect_sense();
+        step_ = Step::SETTLE;
         request_sent_ms_ = now_ms;
-        step_ = Step::WAIT_DETECT_RESP;
+        break;
+
+    case Step::SETTLE:
+        if (now_ms - request_sent_ms_ >= SETTLE_MS) {
+            send_detect_sense();
+            request_sent_ms_ = now_ms;
+            step_ = Step::WAIT_DETECT_RESP;
+        }
         break;
 
     case Step::WAIT_DETECT_RESP: {

--- a/src/row/lib/row_core/sense_mapper.h
+++ b/src/row/lib/row_core/sense_mapper.h
@@ -20,13 +20,19 @@ public:
     const TileMap &result() const { return map_; }
 
 private:
-    enum class Step : uint8_t { START, WAIT_DETECT_RESP, WAIT_ACTIVATE_ACK };
+    enum class Step : uint8_t { START, SETTLE, WAIT_DETECT_RESP, WAIT_ACTIVATE_ACK };
 
     // 3 total attempts per docs/tile-bus-protocol.md §7 (1 initial + 2 retries).
     static constexpr uint8_t  MAX_RETRIES = 2;
     // 5ms placeholder per docs/tile-bus-protocol.md §7's "Response timeout
     // value: 5ms is a placeholder" note.
     static constexpr uint32_t TIMEOUT_MS  = 5;
+    // Settle time after asserting/releasing a SENSE line before broadcasting
+    // the next DETECT_SENSE, so the just-released tile's sense_in has time
+    // to actually go low/deassert before we ask again. Without this, a not-
+    // yet-released tile can still answer alongside the newly-revealed one.
+    // Matches test_sense_mapping.py's proven time.sleep(0.02) between steps.
+    static constexpr uint32_t SETTLE_MS = 20;
 
     void send_detect_sense();
     void send_activate_sense(uint8_t addr);

--- a/src/row/src/main_native.cpp
+++ b/src/row/src/main_native.cpp
@@ -1,6 +1,49 @@
 #include <cstdio>
+#include <cstdlib>
+#include <chrono>
+#include "native/tile_transport_native.h"
+#include "native/row_sense_native.h"
+#include "sense_mapper.h"
 
-int main() {
-    printf("row controller (native): not yet implemented\n");
+static uint32_t now_ms() {
+    using namespace std::chrono;
+    return (uint32_t)duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <row>\n"
+                        "  row  Tile Bus broker row number (matches tile-bus-broker's <row> arg)\n",
+                argv[0]);
+        return 1;
+    }
+    int row = atoi(argv[1]);
+
+    TileTransportNative transport(row);
+    transport.init();
+    RowSenseNative sense(transport.get_fd());
+
+    TileMap     map;
+    SenseMapper mapper(transport, sense, map);
+
+    printf("[row controller] connected to broker for row %d, running SENSE discovery...\n", row);
+
+    mapper.start();
+    while (mapper.state() == SenseMapState::DISCOVERING) {
+        mapper.poll(now_ms());
+    }
+
+    if (mapper.state() == SenseMapState::ERROR) {
+        printf("[row controller] SENSE mapping FAILED\n");
+        return 1;
+    }
+
+    printf("[row controller] discovered %u tile(s):\n", map.discovered_count());
+    for (uint8_t slot = 0; slot < TileMap::NUM_SLOTS; slot++) {
+        if (!map.is_discovered(slot)) continue;
+        printf("  slot %u -> addr 0x%02X (retries=%u)\n",
+               slot, map.address_for(slot), map.retry_count(slot));
+    }
+
     return 0;
 }

--- a/src/row/src/native/broker_msg.h
+++ b/src/row/src/native/broker_msg.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <stdint.h>
+
+// Socket framing between tiles/row-controller and the bus broker
+// (src/tile/tools/tile-bus-broker). This is a deliberate copy, not a shared
+// header, per issue #34: it's a native-testing-only wire contract with a
+// separate, unmodified binary, not the real Tile Bus protocol (which *is*
+// shared - see src/common/tile_bus_protocol/). Keep byte-for-byte identical
+// to src/tile/src/native/broker_msg.h.
+//
+// Every message on the socket starts with a 1-byte type, followed by a
+// type-specific payload.
+//
+//  FRAME             0x01  [len:1] [frame bytes:len]  — raw tile-bus frame
+//  IDENTIFY          0x02  [tile_addr:1] [slot:1]     — sent once on connect
+//  SENSE_ASSERT      0x03  []                         — tile N → broker (sense out low)
+//  SENSE_RELEASE     0x04  []                         — tile N → broker (sense out released)
+//  SENSE_IS_ASSERTED 0x05  []                         — broker → tile N+1 (sense in low)
+//  SENSE_DEASSERTED  0x06  []                         — broker → tile N+1 (sense in released)
+//
+// SENSE routing: slot N SENSE_ASSERT → slot (uint8_t)(N+1) gets SENSE_IS_ASSERTED.
+// Row controller uses slot 0xFF; uint8_t wrap means its assertion reaches slot 0.
+
+enum class BrokerMsg : uint8_t {
+    FRAME             = 0x01,
+    IDENTIFY          = 0x02,
+    SENSE_ASSERT      = 0x03,
+    SENSE_RELEASE     = 0x04,
+    SENSE_IS_ASSERTED = 0x05,
+    SENSE_DEASSERTED  = 0x06,
+};

--- a/src/row/src/native/row_sense_native.cpp
+++ b/src/row/src/native/row_sense_native.cpp
@@ -1,0 +1,13 @@
+#include "row_sense_native.h"
+#include "broker_msg.h"
+#include <unistd.h>
+
+void RowSenseNative::assert_out() {
+    uint8_t byte = (uint8_t)BrokerMsg::SENSE_ASSERT;
+    write(fd, &byte, 1);
+}
+
+void RowSenseNative::release_out() {
+    uint8_t byte = (uint8_t)BrokerMsg::SENSE_RELEASE;
+    write(fd, &byte, 1);
+}

--- a/src/row/src/native/row_sense_native.h
+++ b/src/row/src/native/row_sense_native.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "row_sense_control.h"
+
+// Shares TileTransportNative's socket fd - SENSE and FRAME messages
+// interleave on the same broker connection.
+class RowSenseNative : public IRowSenseControl {
+    int fd;
+public:
+    explicit RowSenseNative(int fd) : fd(fd) {}
+
+    void assert_out() override;    // write SENSE_ASSERT (0x03)
+    void release_out() override;   // write SENSE_RELEASE (0x04)
+};

--- a/src/row/src/native/tile_transport_native.cpp
+++ b/src/row/src/native/tile_transport_native.cpp
@@ -1,0 +1,83 @@
+#include "tile_transport_native.h"
+#include "broker_msg.h"
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+// Row controller's fixed identity on the broker: addr=0x00, slot=0xFF (the
+// 0xFF wraps to slot 0 in the broker's SENSE routing - see broker_msg.h).
+static constexpr uint8_t ROW_CONTROLLER_ADDR = 0x00;
+static constexpr uint8_t ROW_CONTROLLER_SLOT = 0xFF;
+
+TileTransportNative::TileTransportNative(int r) : row(r) {}
+
+void TileTransportNative::init() {
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) { perror("socket"); exit(1); }
+
+    char path[64];
+    snprintf(path, sizeof(path), "/tmp/df2-tile-bus-%d.sock", row);
+
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("connect");
+        exit(1);
+    }
+
+    uint8_t msg[3] = {(uint8_t)BrokerMsg::IDENTIFY, ROW_CONTROLLER_ADDR, ROW_CONTROLLER_SLOT};
+    write(fd, msg, sizeof(msg));
+}
+
+// Reads one byte from the socket (non-blocking). Drives the broker-protocol
+// state machine; feeds frame bytes to parser. Returns true exactly once per
+// complete tile-bus frame received, filling *out.
+bool TileTransportNative::poll(FrameParser &parser, Frame *out) {
+    uint8_t byte;
+    if (recv(fd, &byte, 1, MSG_DONTWAIT) != 1) return false;
+
+    switch (rx_state) {
+    case RxState::TYPE:
+        switch (static_cast<BrokerMsg>(byte)) {
+        case BrokerMsg::FRAME:
+            rx_state = RxState::FRAME_LEN;
+            break;
+        case BrokerMsg::SENSE_IS_ASSERTED:
+        case BrokerMsg::SENSE_DEASSERTED:
+            // The row controller has no incoming SENSE line to update (it's
+            // the head of the chain) - the broker shouldn't send these to
+            // slot 0xFF anyway, but ignore them defensively if it ever did.
+            break;
+        default:
+            break;
+        }
+        return false;
+
+    case RxState::FRAME_LEN:
+        rx_frame_remaining = byte;
+        rx_state = (byte == 0) ? RxState::TYPE : RxState::FRAME_DATA;
+        return false;
+
+    case RxState::FRAME_DATA: {
+        bool complete = parser.feed(byte, out);
+        if (--rx_frame_remaining == 0) rx_state = RxState::TYPE;
+        return complete;
+    }
+    }
+    return false;
+}
+
+void TileTransportNative::send(const Frame &frame) {
+    uint8_t raw[MAX_FRAME_SIZE];
+    int n = frame_encode(frame, raw, sizeof(raw));
+    if (n < 0) return;
+
+    uint8_t header[2] = {(uint8_t)BrokerMsg::FRAME, (uint8_t)n};
+    write(fd, header, sizeof(header));
+    write(fd, raw, n);
+}

--- a/src/row/src/native/tile_transport_native.h
+++ b/src/row/src/native/tile_transport_native.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "transport.h"
+
+class TileTransportNative : public ITransport {
+    int fd = -1;
+    int row;
+
+    // Read state machine for the broker socket protocol.
+    enum class RxState : uint8_t { TYPE, FRAME_LEN, FRAME_DATA };
+    RxState rx_state          = RxState::TYPE;
+    uint8_t rx_frame_remaining = 0;
+
+public:
+    explicit TileTransportNative(int row);
+
+    int get_fd() const { return fd; }
+
+    void init() override;   // connect to /tmp/df2-tile-bus-<row>.sock, IDENTIFY(addr=0x00, slot=0xFF)
+    bool poll(FrameParser &parser, Frame *out) override;
+    void send(const Frame &frame) override;
+};

--- a/src/row/test/integration/test_native_discovery.py
+++ b/src/row/test/integration/test_native_discovery.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Integration test: native row controller vs. the tile project's tile-bus-broker.
+
+Starts tile-bus-broker and 8 native mock-tile processes (both from the tile
+project), then runs this project's own native row-controller binary against
+the same broker socket, exercising the real TileTransportNative +
+RowSenseNative + SenseMapper stack end to end - no hardware, no mocked RC.
+
+Requires (build before running):
+  cd ../../../tile && pio run -e native   ->  .pio/build/native/program (mock-tile)
+  cd ../../../tile/tools && make          ->  tools/bin/tile-bus-broker
+  pio run -e native                       ->  .pio/build/native/program (row controller)
+
+Usage:
+  python3 test/integration/test_native_discovery.py
+"""
+
+import os
+import re
+import sys
+import time
+import subprocess
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+_HERE         = os.path.dirname(os.path.abspath(__file__))
+_ROW_PROJECT  = os.path.abspath(os.path.join(_HERE, '..', '..'))
+_TILE_PROJECT = os.path.abspath(os.path.join(_ROW_PROJECT, '..', 'tile'))
+
+BROKER   = os.path.join(_TILE_PROJECT, 'tools', 'bin', 'tile-bus-broker')
+TILE_BIN = os.path.join(_TILE_PROJECT, '.pio', 'build', 'native', 'program')
+ROW_BIN  = os.path.join(_ROW_PROJECT, '.pio', 'build', 'native', 'program')
+
+ROW  = 0
+SOCK = f'/tmp/df2-tile-bus-{ROW}.sock'
+
+# 8 tiles: addr = slot + 1, matching test_sense_mapping.py's convention.
+TILES = [(0x01 + i, i) for i in range(8)]
+
+ROW_BIN_TIMEOUT = 5.0  # seconds to let the row controller finish discovery
+
+_SLOT_LINE = re.compile(r'slot (\d+) -> addr 0x([0-9A-Fa-f]+)')
+
+
+def run_discovery() -> bool:
+    proc = subprocess.run(
+        [ROW_BIN, str(ROW)],
+        capture_output=True,
+        text=True,
+        timeout=ROW_BIN_TIMEOUT,
+    )
+    print(proc.stdout, end='')
+    if proc.stderr:
+        print(proc.stderr, end='', file=sys.stderr)
+
+    found = {int(slot): int(addr, 16) for slot, addr in _SLOT_LINE.findall(proc.stdout)}
+
+    print()
+    print(f'Mapping ({len(found)} tile(s) discovered):')
+    failures = []
+    for expected_addr, slot in TILES:
+        actual = found.get(slot)
+        status = 'ok' if actual == expected_addr else f'FAIL (expected 0x{expected_addr:02X})'
+        print(f'  slot {slot}  ->  addr 0x{actual:02X}  [{status}]' if actual is not None
+              else f'  slot {slot}  ->  MISSING  [FAIL]')
+        if actual != expected_addr:
+            failures.append(f'slot {slot}: expected 0x{expected_addr:02X}, got {actual}')
+
+    extra = set(found) - {slot for _, slot in TILES}
+    for slot in extra:
+        failures.append(f'unexpected extra slot {slot} (addr 0x{found[slot]:02X})')
+
+    print()
+    if failures or proc.returncode != 0:
+        if proc.returncode != 0:
+            failures.append(f'row controller exited {proc.returncode}')
+        for msg in failures:
+            print(f'  FAIL: {msg}')
+        return False
+
+    print('  PASS')
+    return True
+
+
+def main() -> int:
+    for path, hint in [
+        (BROKER,   'run: make -C ../tile/tools'),
+        (TILE_BIN, 'run: (cd ../tile && pio run -e native)'),
+        (ROW_BIN,  'run: pio run -e native'),
+    ]:
+        if not os.path.isfile(path):
+            print(f'ERROR: binary not found: {path}')
+            print(f'       {hint}')
+            return 1
+
+    try:
+        os.unlink(SOCK)
+    except FileNotFoundError:
+        pass
+
+    procs: list[subprocess.Popen] = []
+    try:
+        procs.append(subprocess.Popen(
+            [BROKER, str(ROW)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        ))
+        time.sleep(0.15)  # wait for the Unix socket to be created
+
+        for addr, slot in TILES:
+            procs.append(subprocess.Popen(
+                [TILE_BIN, f'0x{addr:02X}', str(slot), str(ROW)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            ))
+
+        time.sleep(0.5)  # let all 8 tiles connect and IDENTIFY with the broker
+
+        return 0 if run_discovery() else 1
+
+    finally:
+        for p in procs:
+            p.terminate()
+        for p in procs:
+            try:
+                p.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                p.kill()
+        try:
+            os.unlink(SOCK)
+        except FileNotFoundError:
+            pass
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/row/test/integration/test_native_discovery.py
+++ b/src/row/test/integration/test_native_discovery.py
@@ -7,10 +7,11 @@ project), then runs this project's own native row-controller binary against
 the same broker socket, exercising the real TileTransportNative +
 RowSenseNative + SenseMapper stack end to end - no hardware, no mocked RC.
 
-Requires (build before running):
-  cd ../../../tile && pio run -e native   ->  .pio/build/native/program (mock-tile)
-  cd ../../../tile/tools && make          ->  tools/bin/tile-bus-broker
-  pio run -e native                       ->  .pio/build/native/program (row controller)
+Always rebuilds all three artifacts first (tile-bus-broker via `make`, both
+native binaries via `pio run -e native`) rather than just checking they
+exist - `pio test -e native` overwrites the same binary path with its own
+test binary, so an existing file is not proof it's the right program.
+`make`/`pio run` are incremental, so this is cheap when nothing's changed.
 
 Usage:
   python3 test/integration/test_native_discovery.py
@@ -42,6 +43,35 @@ TILES = [(0x01 + i, i) for i in range(8)]
 ROW_BIN_TIMEOUT = 5.0  # seconds to let the row controller finish discovery
 
 _SLOT_LINE = re.compile(r'slot (\d+) -> addr 0x([0-9A-Fa-f]+)')
+
+
+def ensure_built() -> bool:
+    """Always (re)build all three artifacts - never just check for
+    presence. `pio test -e native` overwrites the same
+    .pio/build/native/program path with its own test binary, so a file that
+    merely *exists* isn't proof it's the right one; `make`/`pio run` are
+    incremental and near-instant when nothing's actually changed, so paying
+    for a real build here is cheap and guarantees freshness either way.
+    Returns False (with an error printed) if a build step fails."""
+    print('Building tile-bus-broker...')
+    result = subprocess.run(['make'], cwd=os.path.join(_TILE_PROJECT, 'tools'))
+    if result.returncode != 0 or not os.path.isfile(BROKER):
+        print(f'ERROR: failed to build {BROKER}')
+        return False
+
+    print('Building tile project native mock (pio run -e native)...')
+    result = subprocess.run(['pio', 'run', '-e', 'native'], cwd=_TILE_PROJECT)
+    if result.returncode != 0 or not os.path.isfile(TILE_BIN):
+        print(f'ERROR: failed to build {TILE_BIN}')
+        return False
+
+    print('Building row controller native binary (pio run -e native)...')
+    result = subprocess.run(['pio', 'run', '-e', 'native'], cwd=_ROW_PROJECT)
+    if result.returncode != 0 or not os.path.isfile(ROW_BIN):
+        print(f'ERROR: failed to build {ROW_BIN}')
+        return False
+
+    return True
 
 
 def run_discovery() -> bool:
@@ -85,15 +115,8 @@ def run_discovery() -> bool:
 
 
 def main() -> int:
-    for path, hint in [
-        (BROKER,   'run: make -C ../tile/tools'),
-        (TILE_BIN, 'run: (cd ../tile && pio run -e native)'),
-        (ROW_BIN,  'run: pio run -e native'),
-    ]:
-        if not os.path.isfile(path):
-            print(f'ERROR: binary not found: {path}')
-            print(f'       {hint}')
-            return 1
+    if not ensure_built():
+        return 1
 
     try:
         os.unlink(SOCK)


### PR DESCRIPTION
## Summary
- Adds `TileTransportNative`/`RowSenseNative` (`src/native/tile_transport_native.{h,cpp}`, `src/native/row_sense_native.{h,cpp}`): implement the shared `ITransport` (#28) and `IRowSenseControl` (#29) as a client of the tile project's existing `tile-bus-broker`, always identifying as `(addr=0x00, slot=0xFF)` so the broker's `uint8_t` slot-wrap routes this row controller's `SENSE_ASSERT`/`SENSE_RELEASE` to tile slot 0
- `src/native/broker_msg.h`: a deliberate copy of the broker's socket-framing constants (not shared/included) — it's native-testing-only plumbing around a separate, unmodified binary, distinct from the real Tile Bus protocol (which *is* shared via `src/common/tile_bus_protocol/`)
- `main_native.cpp` now actually runs `SenseMapper` against a real `tile-bus-broker` + native tile mocks and reports the discovered mapping, instead of a placeholder print

## Bug found and fixed along the way
Running this for real against the tile project's broker + 8 native tile mocks surfaced a genuine race in `SenseMapper` (#29): it broadcasts the next `DETECT_SENSE` immediately after releasing/`CLEAR_SENSE`-ing the previous slot, with no settle time for that release to actually propagate through the broker to the next tile process. A not-yet-released tile could still answer alongside the newly-revealed one — producing duplicate addresses and running out of slots before reaching the real last tile or two. `test_sense_mapping.py`'s own proven Python implementation sleeps 20ms between these exact steps for this reason; added the same settle delay as a new non-blocking `SETTLE` state in the state machine (`sense_mapper.{h,cpp}`).

Added `test/integration/test_native_discovery.py` (mirrors `test_sense_mapping.py`'s structure) as a permanent regression test: spins up `tile-bus-broker` + 8 native tile mocks + this project's real native row-controller binary, checks the reported mapping matches `slot i -> addr (i+1)` for all 8. It **always rebuilds all three artifacts** before running rather than just checking they exist — `pio test -e native` overwrites the same `.pio/build/native/program` path with its own test binary, so an existing file isn't proof it's the right program. `make`/`pio run` are incremental, so this is cheap when nothing's changed, and verified to self-heal when something has (deliberately clobbered both native binaries via `pio test`, confirmed the script rebuilds them and still passes).

## Test plan
- [x] `pio run -e native` builds with no Arduino/RP2350 headers
- [x] `pio test -e native` — all 9 existing unit tests still pass (fake-transport tests are unaffected by the settle delay, since they advance a simulated clock)
- [x] `pio run` for all six row-project hardware envs — unaffected
- [x] `python3 test/integration/test_native_discovery.py` — PASS, 8/8 tiles, `slot i -> addr (i+1)`, zero retries; reproduced the duplicate-address failure before the `SETTLE` fix, confirmed stable across multiple repeated runs after it

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
