### PR TITLE
[Row Controller] Common: Row Bus command handler

### DIFF
--- a/src/row/lib/row_core/row_command_handler.cpp
+++ b/src/row/lib/row_core/row_command_handler.cpp
@@ -1,0 +1,135 @@
+#include "row_command_handler.h"
+
+RowCommandHandler::RowCommandHandler(ITransport &tile_transport, SenseMapper &sense,
+                                      IPowerMonitor &power, uint8_t my_row_addr)
+    : tile_transport_(tile_transport), sense_(sense), power_(power), my_row_addr_(my_row_addr) {}
+
+void RowCommandHandler::send_tile_frame(uint8_t addr, Cmd cmd, const uint8_t *payload, uint8_t len) {
+    Frame f{};
+    f.addr = addr;
+    f.cmd  = (uint8_t)cmd;
+    f.len  = len;
+    for (uint8_t i = 0; i < len; i++) f.payload[i] = payload[i];
+    tile_transport_.send(f);
+}
+
+void RowCommandHandler::broadcast_tile_latch() {
+    Frame f{};
+    f.addr = ADDR_BROADCAST;
+    f.cmd  = (uint8_t)Cmd::LATCH;
+    f.len  = 0;
+    tile_transport_.send(f);
+}
+
+// Stub: real self-test (Row Bus UART loopback, Tile Bus transceiver, SRAM)
+// needs platform hooks that don't exist yet.
+void RowCommandHandler::handle_test() {
+    response_.addr = my_row_addr_;
+    response_.cmd  = (uint8_t)RowBusCmd::TEST_RESP;
+    response_.len  = 2;
+    response_.payload[0] = 0x00; // result: all pass
+    response_.payload[1] = 0x00; // fault_flags: none
+}
+
+void RowCommandHandler::handle_status() {
+    const TileMap &map = sense_.result();
+
+    response_.addr = my_row_addr_;
+    response_.cmd  = (uint8_t)RowBusCmd::STATUS_RESP;
+    response_.len  = 10;
+    // SenseMapState's declaration order (IDLE, DISCOVERING, DONE, ERROR)
+    // already matches the wire's 0x00-0x03 (idle/discovering/running/error).
+    response_.payload[0] = (uint8_t)sense_.state();
+    response_.payload[1] = map.discovered_count();
+    for (uint8_t slot = 0; slot < TileMap::NUM_SLOTS; slot++)
+        response_.payload[2 + slot] = (uint8_t)map.status_for(slot);
+}
+
+void RowCommandHandler::handle_power() {
+    PowerReading reading = power_.read();
+
+    response_.addr = my_row_addr_;
+    response_.cmd  = (uint8_t)RowBusCmd::POWER_RESP;
+    response_.len  = 6;
+    response_.payload[0] = (uint8_t)(reading.voltage_mV >> 8);
+    response_.payload[1] = (uint8_t)(reading.voltage_mV & 0xFF);
+    response_.payload[2] = (uint8_t)(reading.current_mA >> 8);
+    response_.payload[3] = (uint8_t)(reading.current_mA & 0xFF);
+    response_.payload[4] = (uint8_t)(reading.power_mW >> 8);
+    response_.payload[5] = (uint8_t)(reading.power_mW & 0xFF);
+}
+
+void RowCommandHandler::handle_re_discover() {
+    sense_.start(); // proceeds asynchronously via the caller's regular sense_.poll() loop
+
+    response_.addr = my_row_addr_;
+    response_.cmd  = (uint8_t)RowBusCmd::RE_DISCOVER_RESP;
+    response_.len  = 1;
+    response_.payload[0] = 0x00; // started
+}
+
+// Stub: the 32-entry ring buffer this needs doesn't have a producer yet -
+// wire this up once Tile Bus retry logic exists in concrete transports.
+void RowCommandHandler::handle_error_log() {
+    response_.addr = my_row_addr_;
+    response_.cmd  = (uint8_t)RowBusCmd::ERROR_LOG_RESP;
+    response_.len  = 1;
+    response_.payload[0] = 0x00; // entry_count
+}
+
+void RowCommandHandler::handle_send_data(const RowBusFrame &in) {
+    const TileMap &map = sense_.result();
+    uint16_t offset = 0;
+
+    for (uint8_t slot = 0; slot < TileMap::NUM_SLOTS; slot++) {
+        if (offset >= in.len) break; // short/malformed frame - stop rather than read garbage
+
+        uint8_t tile_cmd = in.payload[offset];
+        uint8_t data_len;
+        switch ((Cmd)tile_cmd) {
+        case Cmd::SET_COLOR:   data_len = 3;   break;
+        case Cmd::SET_PATTERN: data_len = 5;   break;
+        case Cmd::SET_LEDS:    data_len = 120; break;
+        default: return; // unrecognized tile_cmd - can't know its size, stop parsing
+        }
+
+        if (map.is_discovered(slot))
+            send_tile_frame(map.address_for(slot), (Cmd)tile_cmd, &in.payload[offset + 1], data_len);
+        // else: slot not discovered - skip forwarding, still advance offset below
+
+        offset = (uint16_t)(offset + 1 + data_len);
+    }
+}
+
+// TODO(#46): overrun buffering - defer this LATCH if still forwarding a
+// SEND_DATA that hasn't finished, per docs/row-bus-protocol.md's
+// LATCH_OVERRUN handling. Not tracked yet; needs real Tile Bus forwarding
+// timing to design against.
+void RowCommandHandler::handle_latch() {
+    broadcast_tile_latch();
+}
+
+void RowCommandHandler::handle_blackout() {
+    const TileMap &map = sense_.result();
+    const uint8_t black[3] = {0, 0, 0};
+
+    for (uint8_t slot = 0; slot < TileMap::NUM_SLOTS; slot++) {
+        if (!map.is_discovered(slot)) continue;
+        send_tile_frame(map.address_for(slot), Cmd::SET_COLOR, black, sizeof(black));
+    }
+    broadcast_tile_latch();
+}
+
+const RowBusFrame *RowCommandHandler::handle(const RowBusFrame &in) {
+    switch ((RowBusCmd)in.cmd) {
+    case RowBusCmd::TEST:         handle_test();         return &response_;
+    case RowBusCmd::STATUS:       handle_status();       return &response_;
+    case RowBusCmd::POWER:        handle_power();        return &response_;
+    case RowBusCmd::RE_DISCOVER:  handle_re_discover();  return &response_;
+    case RowBusCmd::ERROR_LOG:    handle_error_log();    return &response_;
+    case RowBusCmd::SEND_DATA:    handle_send_data(in);  return nullptr;
+    case RowBusCmd::LATCH:        handle_latch();        return nullptr;
+    case RowBusCmd::BLACKOUT:     handle_blackout();     return nullptr;
+    default:                                              return nullptr;
+    }
+}

--- a/src/row/lib/row_core/row_command_handler.h
+++ b/src/row/lib/row_core/row_command_handler.h
@@ -1,0 +1,38 @@
+#pragma once
+#include "row_bus_protocol.h"
+#include "protocol.h"   // src/common/tile_bus_protocol/, via lib_extra_dirs
+#include "transport.h"  // src/common/tile_bus_protocol/, via lib_extra_dirs
+#include "sense_mapper.h"
+#include "../../include/power_monitor.h"
+
+// Dispatches Row Bus commands arriving from the Raspberry Pi
+// (docs/row-bus-protocol.md §5). in.addr must already be filtered by the
+// caller (== my_row_addr or broadcast).
+class RowCommandHandler {
+public:
+    RowCommandHandler(ITransport &tile_transport, SenseMapper &sense,
+                       IPowerMonitor &power, uint8_t my_row_addr);
+
+    // Returns a pointer to a statically-allocated response frame, or nullptr
+    // if no response is needed (SEND_DATA / LATCH / BLACKOUT).
+    const RowBusFrame *handle(const RowBusFrame &in);
+
+private:
+    void handle_test();
+    void handle_status();
+    void handle_power();
+    void handle_re_discover();
+    void handle_error_log();
+    void handle_send_data(const RowBusFrame &in);
+    void handle_latch();
+    void handle_blackout();
+
+    void send_tile_frame(uint8_t addr, Cmd cmd, const uint8_t *payload, uint8_t len);
+    void broadcast_tile_latch();
+
+    ITransport    &tile_transport_;
+    SenseMapper   &sense_;
+    IPowerMonitor &power_;
+    uint8_t        my_row_addr_;
+    RowBusFrame    response_ = {};
+};

--- a/src/row/test/test_row_command_handler/test_row_command_handler.cpp
+++ b/src/row/test/test_row_command_handler/test_row_command_handler.cpp
@@ -1,0 +1,308 @@
+#include <unity.h>
+#include <vector>
+#include "row_command_handler.h"
+
+void setUp() {}
+void tearDown() {}
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeTileTransport : public ITransport {
+public:
+    void init() override {}
+    bool poll(FrameParser &, Frame *) override { return false; }
+    void send(const Frame &frame) override { sent.push_back(frame); }
+    std::vector<Frame> sent;
+};
+
+class FakeRowSense : public IRowSenseControl {
+public:
+    void assert_out() override {}
+    void release_out() override {}
+};
+
+class FakePowerMonitor : public IPowerMonitor {
+public:
+    PowerReading reading{};
+    void init() override {}
+    PowerReading read() override { return reading; }
+};
+
+static RowBusFrame make_frame(uint8_t addr, RowBusCmd cmd, const uint8_t *payload, uint16_t len) {
+    RowBusFrame f{};
+    f.addr = addr;
+    f.cmd  = (uint8_t)cmd;
+    f.len  = len;
+    for (uint16_t i = 0; i < len; i++) f.payload[i] = payload[i];
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// STATUS
+// ---------------------------------------------------------------------------
+
+void test_status_reports_discovered_tiles_and_state() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    map.set_discovered(0, 0x01);
+    map.set_discovered(1, 0x02);
+    map.set_discovered(2, 0x03);
+    map.set_discovered(3, 0x04);
+    map.set_discovered(4, 0x05);
+    // slots 5,6,7 remain not-discovered
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(0x00, RowBusCmd::STATUS, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NOT_NULL(resp);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)RowBusCmd::STATUS_RESP, resp->cmd);
+    TEST_ASSERT_EQUAL(10, resp->len);
+    TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[0]); // state: IDLE (discovery never started)
+    TEST_ASSERT_EQUAL(5, resp->payload[1]);          // tiles_found
+    for (uint8_t i = 0; i < 5; i++)
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)TileStatus::OK, resp->payload[2 + i]);
+    for (uint8_t i = 5; i < 8; i++)
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)TileStatus::NOT_DISCOVERED, resp->payload[2 + i]);
+}
+
+// ---------------------------------------------------------------------------
+// POWER
+// ---------------------------------------------------------------------------
+
+void test_power_reports_reading_fields() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+    power.reading = {12043, 812, 9779};
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(0x00, RowBusCmd::POWER, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NOT_NULL(resp);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)RowBusCmd::POWER_RESP, resp->cmd);
+    TEST_ASSERT_EQUAL(6, resp->len);
+    TEST_ASSERT_EQUAL_HEX8(12043 >> 8,   resp->payload[0]);
+    TEST_ASSERT_EQUAL_HEX8(12043 & 0xFF, resp->payload[1]);
+    TEST_ASSERT_EQUAL_HEX8(812 >> 8,     resp->payload[2]);
+    TEST_ASSERT_EQUAL_HEX8(812 & 0xFF,   resp->payload[3]);
+    TEST_ASSERT_EQUAL_HEX8(9779 >> 8,    resp->payload[4]);
+    TEST_ASSERT_EQUAL_HEX8(9779 & 0xFF,  resp->payload[5]);
+}
+
+// ---------------------------------------------------------------------------
+// SEND_DATA
+// ---------------------------------------------------------------------------
+
+void test_send_data_forwards_mixed_commands_to_correct_addresses() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    for (uint8_t i = 0; i < 8; i++) map.set_discovered(i, (uint8_t)(i + 1));
+
+    // slots 0-6: SET_COLOR: slot 7: SET_LEDS.
+    uint8_t payload[8 * 121] = {};
+    uint16_t offset = 0;
+    for (uint8_t slot = 0; slot < 7; slot++) {
+        payload[offset++] = (uint8_t)Cmd::SET_COLOR;
+        payload[offset++] = (uint8_t)(slot * 10);
+        payload[offset++] = (uint8_t)(slot * 10 + 1);
+        payload[offset++] = (uint8_t)(slot * 10 + 2);
+    }
+    payload[offset++] = (uint8_t)Cmd::SET_LEDS;
+    for (uint16_t i = 0; i < 120; i++) payload[offset++] = (uint8_t)i;
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(0x00, RowBusCmd::SEND_DATA, payload, offset);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NULL(resp); // fire-and-forget, no response
+    TEST_ASSERT_EQUAL(8, transport.sent.size());
+
+    for (uint8_t slot = 0; slot < 7; slot++) {
+        const Frame &f = transport.sent[slot];
+        TEST_ASSERT_EQUAL_HEX8(slot + 1, f.addr);
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)Cmd::SET_COLOR, f.cmd);
+        TEST_ASSERT_EQUAL(3, f.len);
+        TEST_ASSERT_EQUAL_HEX8(slot * 10,     f.payload[0]);
+        TEST_ASSERT_EQUAL_HEX8(slot * 10 + 1, f.payload[1]);
+        TEST_ASSERT_EQUAL_HEX8(slot * 10 + 2, f.payload[2]);
+    }
+
+    const Frame &last = transport.sent[7];
+    TEST_ASSERT_EQUAL_HEX8(8, last.addr);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)Cmd::SET_LEDS, last.cmd);
+    TEST_ASSERT_EQUAL(120, last.len);
+    for (uint16_t i = 0; i < 120; i++)
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)i, last.payload[i]);
+}
+
+void test_send_data_skips_undiscovered_slots() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    map.set_discovered(0, 0x01);
+    // slots 1-7 not discovered
+
+    uint8_t payload[8 * 4] = {};
+    uint16_t offset = 0;
+    for (uint8_t slot = 0; slot < 8; slot++) {
+        payload[offset++] = (uint8_t)Cmd::SET_COLOR;
+        payload[offset++] = 1; payload[offset++] = 2; payload[offset++] = 3;
+    }
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(0x00, RowBusCmd::SEND_DATA, payload, offset);
+    handler.handle(req);
+
+    // Only slot 0 is discovered, but the parser must still walk all 8
+    // fixed-size entries to stay aligned - if offset tracking were wrong,
+    // this would either crash or miscount.
+    TEST_ASSERT_EQUAL(1, transport.sent.size());
+    TEST_ASSERT_EQUAL_HEX8(0x01, transport.sent[0].addr);
+}
+
+// ---------------------------------------------------------------------------
+// LATCH / BLACKOUT
+// ---------------------------------------------------------------------------
+
+void test_latch_broadcasts_tile_latch() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(ROWBUS_ADDR_BROADCAST, RowBusCmd::LATCH, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NULL(resp);
+    TEST_ASSERT_EQUAL(1, transport.sent.size());
+    TEST_ASSERT_EQUAL_HEX8(ADDR_BROADCAST, transport.sent[0].addr);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)Cmd::LATCH, transport.sent[0].cmd);
+}
+
+void test_blackout_sends_black_to_each_discovered_tile_then_latch() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    for (uint8_t i = 0; i < 8; i++) map.set_discovered(i, (uint8_t)(i + 1));
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(ROWBUS_ADDR_BROADCAST, RowBusCmd::BLACKOUT, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NULL(resp);
+    TEST_ASSERT_EQUAL(9, transport.sent.size()); // 8 SET_COLOR + 1 LATCH
+
+    for (uint8_t i = 0; i < 8; i++) {
+        const Frame &f = transport.sent[i];
+        TEST_ASSERT_EQUAL_HEX8(i + 1, f.addr);
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)Cmd::SET_COLOR, f.cmd);
+        TEST_ASSERT_EQUAL(3, f.len);
+        TEST_ASSERT_EQUAL_HEX8(0, f.payload[0]);
+        TEST_ASSERT_EQUAL_HEX8(0, f.payload[1]);
+        TEST_ASSERT_EQUAL_HEX8(0, f.payload[2]);
+    }
+
+    const Frame &latch = transport.sent[8];
+    TEST_ASSERT_EQUAL_HEX8(ADDR_BROADCAST, latch.addr);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)Cmd::LATCH, latch.cmd);
+    TEST_ASSERT_EQUAL(0, latch.len);
+}
+
+// ---------------------------------------------------------------------------
+// RE_DISCOVER / TEST / ERROR_LOG
+// ---------------------------------------------------------------------------
+
+void test_re_discover_starts_sense_mapping_and_acks() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(0x00, RowBusCmd::RE_DISCOVER, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NOT_NULL(resp);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)RowBusCmd::RE_DISCOVER_RESP, resp->cmd);
+    TEST_ASSERT_EQUAL(1, resp->len);
+    TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[0]);
+    TEST_ASSERT_EQUAL(SenseMapState::DISCOVERING, sense.state());
+}
+
+void test_test_command_returns_always_pass_stub() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(0x00, RowBusCmd::TEST, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NOT_NULL(resp);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)RowBusCmd::TEST_RESP, resp->cmd);
+    TEST_ASSERT_EQUAL(2, resp->len);
+    TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[1]);
+}
+
+void test_error_log_returns_empty_stub() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame req = make_frame(0x00, RowBusCmd::ERROR_LOG, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NOT_NULL(resp);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)RowBusCmd::ERROR_LOG_RESP, resp->cmd);
+    TEST_ASSERT_EQUAL(1, resp->len);
+    TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+int main(int, char **) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_status_reports_discovered_tiles_and_state);
+    RUN_TEST(test_power_reports_reading_fields);
+    RUN_TEST(test_send_data_forwards_mixed_commands_to_correct_addresses);
+    RUN_TEST(test_send_data_skips_undiscovered_slots);
+    RUN_TEST(test_latch_broadcasts_tile_latch);
+    RUN_TEST(test_blackout_sends_black_to_each_discovered_tile_then_latch);
+    RUN_TEST(test_re_discover_starts_sense_mapping_and_acks);
+    RUN_TEST(test_test_command_returns_always_pass_stub);
+    RUN_TEST(test_error_log_returns_empty_stub);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Adds `lib/row_core/row_command_handler.{h,cpp}`: `RowCommandHandler`, dispatching a decoded `RowBusFrame` per `docs/row-bus-protocol.md` §5
- **`STATUS`**: full — `SenseMapState`'s declaration order (`IDLE, DISCOVERING, DONE, ERROR`) already matches the wire's `state` byte (`0x00-0x03`, "running" = `DONE`) exactly, and `TileStatus`'s values already match `tile_status[]` exactly (both by design, from #29/#37) — no translation needed either way
- **`POWER`**: full, from `IPowerMonitor` (#23)
- **`RE_DISCOVER`**: full — starts `SenseMapper` and ACKs immediately, matching the spec's fire-and-continue-async behavior
- **`SEND_DATA`**: full — walks the 8 fixed-format tile entries, forwards each to its discovered address as an individual Tile Bus frame; always advances the parse offset by the full entry size even when skipping an undiscovered slot, so a gap doesn't misalign later entries (covered by a dedicated test)
- **`BLACKOUT`**: full — `SET_COLOR(0,0,0)` to each discovered tile, then `LATCH`
- **`LATCH`**: minimal — immediate broadcast, no overrun buffering yet (see below)
- **`TEST`/`ERROR_LOG`**: stubs (always-pass / always-empty) per #30's explicit scope — both need platform hooks or a producer that don't exist yet

Filed **#46** for the `LATCH` overrun-buffering + `ERROR_LOG` producer work #30 explicitly deferred, and referenced it in a `TODO(#46)` comment rather than leaving a dangling placeholder.

## Test plan
- [x] `pio test -e native` — 9 new tests pass (all of #30's acceptance criteria, plus `RE_DISCOVER`/`TEST`/`ERROR_LOG` stub coverage), 36 total across the whole suite
- [x] `pio run` for all six row-project hardware envs + `native` — unaffected

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)