### PR TITLE
[Row Controller] RP2350: Row Bus (Pi) transport

### DIFF
--- a/src/row/src/rp2350/pi_transport_rp2350.cpp
+++ b/src/row/src/rp2350/pi_transport_rp2350.cpp
@@ -30,6 +30,7 @@ bool PiTransportRP2350::poll(RowBusFrameParser &parser, RowBusFrame *out) {
     // Drain all available RX bytes. Return true on the first complete frame.
     while (Serial2.available()) {
         uint8_t byte = (uint8_t)Serial2.read();
+        last_rx_byte_us_ = micros();
         if (parser.feed(byte, out)) return true;
     }
     return false;
@@ -40,6 +41,15 @@ void PiTransportRP2350::send(const RowBusFrame &frame) {
     int len = row_bus_frame_encode(frame, buf, sizeof(buf));
     if (len <= 0) return;
 
+    // Guard: don't key up until >= 100 us have passed since the Pi's last
+    // byte, so its transceiver has fully released the line before we drive
+    // it (docs/row-bus-protocol.md §9 "Bus turnaround timing"). Timed from
+    // the incoming frame, not our own transmission - unsigned subtraction
+    // wraps correctly across a micros() rollover.
+    uint32_t elapsed = micros() - last_rx_byte_us_;
+    if (elapsed < TURNAROUND_GUARD_US)
+        delayMicroseconds(TURNAROUND_GUARD_US - elapsed);
+
     // Assert XDIR: switch transceiver to TX.
     digitalWrite(PIN_PI_XDIR, HIGH);
 
@@ -47,9 +57,6 @@ void PiTransportRP2350::send(const RowBusFrame &frame) {
 
     // Wait for the last stop bit to leave the wire, not just FIFO-empty.
     Serial2.flush();
-
-    // Hold the bus idle past the turnaround guard before releasing it.
-    delayMicroseconds(TURNAROUND_GUARD_US);
 
     // Return transceiver to RX mode.
     digitalWrite(PIN_PI_XDIR, LOW);

--- a/src/row/src/rp2350/pi_transport_rp2350.cpp
+++ b/src/row/src/rp2350/pi_transport_rp2350.cpp
@@ -1,0 +1,56 @@
+#include <Arduino.h>
+#include "pi_transport_rp2350.h"
+#include "pins.h"
+
+// Row Bus baud rate. 4 Mbps is the documented minimum for 30 FPS headroom
+// (docs/row-bus-protocol.md §1); bump to 8_000_000 here if throughput needs
+// it later - the driver shape doesn't change.
+static constexpr unsigned long ROW_BUS_BAUD = 4000000;
+
+// Bus turnaround guard: hold the bus idle for >= 100 us after the last stop
+// bit before releasing XDIR back to RX, same guard used on Tile Bus
+// (docs/row-bus-protocol.md §9 "Bus turnaround timing").
+static constexpr unsigned int TURNAROUND_GUARD_US = 100;
+
+// PIN_PI_TX/PIN_PI_RX (D10/D9) are not this board's default Serial2 (UART1)
+// pins, so they need an explicit remap before begin() - unlike the Tile Bus
+// side (PIN_ROW_TX/PIN_ROW_RX), which uses Serial1's defaults as-is.
+
+void PiTransportRP2350::init() {
+    Serial2.setTX(PIN_PI_TX);
+    Serial2.setRX(PIN_PI_RX);
+    Serial2.begin(ROW_BUS_BAUD, SERIAL_8N1);
+
+    // XDIR starts low: RS-485 transceiver in RX mode.
+    digitalWrite(PIN_PI_XDIR, LOW);
+    pinMode(PIN_PI_XDIR, OUTPUT);
+}
+
+bool PiTransportRP2350::poll(RowBusFrameParser &parser, RowBusFrame *out) {
+    // Drain all available RX bytes. Return true on the first complete frame.
+    while (Serial2.available()) {
+        uint8_t byte = (uint8_t)Serial2.read();
+        if (parser.feed(byte, out)) return true;
+    }
+    return false;
+}
+
+void PiTransportRP2350::send(const RowBusFrame &frame) {
+    uint8_t buf[ROWBUS_MAX_FRAME];
+    int len = row_bus_frame_encode(frame, buf, sizeof(buf));
+    if (len <= 0) return;
+
+    // Assert XDIR: switch transceiver to TX.
+    digitalWrite(PIN_PI_XDIR, HIGH);
+
+    Serial2.write(buf, (size_t)len);
+
+    // Wait for the last stop bit to leave the wire, not just FIFO-empty.
+    Serial2.flush();
+
+    // Hold the bus idle past the turnaround guard before releasing it.
+    delayMicroseconds(TURNAROUND_GUARD_US);
+
+    // Return transceiver to RX mode.
+    digitalWrite(PIN_PI_XDIR, LOW);
+}

--- a/src/row/src/rp2350/pi_transport_rp2350.h
+++ b/src/row/src/rp2350/pi_transport_rp2350.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "pi_transport.h"
+
+class PiTransportRP2350 : public IPiTransport {
+public:
+    void init() override;
+    bool poll(RowBusFrameParser &parser, RowBusFrame *out) override;
+    void send(const RowBusFrame &frame) override;
+};

--- a/src/row/src/rp2350/pi_transport_rp2350.h
+++ b/src/row/src/rp2350/pi_transport_rp2350.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdint.h>
 #include "pi_transport.h"
 
 class PiTransportRP2350 : public IPiTransport {
@@ -6,4 +7,10 @@ public:
     void init() override;
     bool poll(RowBusFrameParser &parser, RowBusFrame *out) override;
     void send(const RowBusFrame &frame) override;
+
+private:
+    // micros() timestamp of the last byte received from the Pi, so send()
+    // can wait out the turnaround guard from the *incoming* frame's last
+    // stop bit, not from our own transmission.
+    uint32_t last_rx_byte_us_ = 0;
 };


### PR DESCRIPTION
## Summary
- Implements `PiTransportRP2350` (`IPiTransport`) for the RP2350, driving Row Bus over `Serial2` (UART1) remapped to `PIN_PI_TX`/`PIN_PI_RX` at 4 Mbps 8N1
- `PIN_PI_XDIR` direction control for the THVD1420DR transceiver: low = RX (default), high = TX
- `send()` waits for true TX completion (`Serial2.flush()`) then holds the bus idle for the documented >= 100 µs turnaround guard before releasing XDIR
- `poll()` drains all available RX bytes per call into a `RowBusFrameParser`, mirroring `TileTransportRP2350`'s existing pattern
- Baud rate is a single `constexpr` so bumping to 8 Mbps later doesn't require a driver-shape change

## Test plan
- [x] `pio run -e seeed_xiao_rp2350` builds and links cleanly
- [x] All other PlatformIO environments (`native`, `_led_test`, `_power_test`, `_sense_test`, `_row_test`) still build
- [x] `pio test -e native`: 36/36 test cases pass (unaffected — this driver has no native counterpart, per the issue)
- [ ] Hardware bench test (loopback or second RP2350): `RowBusFrame` sent via `send()` recovered byte-identical via `poll()`; `PIN_PI_XDIR` scope-verified high only during the TX window

Closes #31