### PR TITLE
[Row Controller] Native: Row Bus mock transport + broker

### DIFF
--- a/src/row/src/native/pi_transport_native.cpp
+++ b/src/row/src/native/pi_transport_native.cpp
@@ -1,0 +1,77 @@
+#include "pi_transport_native.h"
+#include "row_broker_msg.h"
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+static constexpr const char *SOCK_PATH = "/tmp/df2-row-bus.sock";
+
+PiTransportNative::PiTransportNative(uint8_t row_addr) : row_addr(row_addr) {}
+
+void PiTransportNative::init() {
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) { perror("socket"); exit(1); }
+
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        perror("connect");
+        exit(1);
+    }
+
+    uint8_t msg[2] = {(uint8_t)RowBrokerMsg::IDENTIFY, row_addr};
+    write(fd, msg, sizeof(msg));
+}
+
+// Reads one byte from the socket (non-blocking). Drives the broker-protocol
+// state machine; feeds frame bytes to parser. Returns true exactly once per
+// complete Row Bus frame received, filling *out.
+bool PiTransportNative::poll(RowBusFrameParser &parser, RowBusFrame *out) {
+    uint8_t byte;
+    if (recv(fd, &byte, 1, MSG_DONTWAIT) != 1) return false;
+
+    switch (rx_state) {
+    case RxState::TYPE:
+        switch (static_cast<RowBrokerMsg>(byte)) {
+        case RowBrokerMsg::FRAME:
+            rx_state = RxState::FRAME_LEN_H;
+            break;
+        default:
+            break;
+        }
+        return false;
+
+    case RxState::FRAME_LEN_H:
+        rx_frame_len = (uint16_t)(byte << 8);
+        rx_state     = RxState::FRAME_LEN_L;
+        return false;
+
+    case RxState::FRAME_LEN_L:
+        rx_frame_len |= byte;
+        rx_frame_remaining = rx_frame_len;
+        rx_state = (rx_frame_len == 0) ? RxState::TYPE : RxState::FRAME_DATA;
+        return false;
+
+    case RxState::FRAME_DATA: {
+        bool complete = parser.feed(byte, out);
+        if (--rx_frame_remaining == 0) rx_state = RxState::TYPE;
+        return complete;
+    }
+    }
+    return false;
+}
+
+void PiTransportNative::send(const RowBusFrame &frame) {
+    uint8_t raw[ROWBUS_MAX_FRAME];
+    int n = row_bus_frame_encode(frame, raw, sizeof(raw));
+    if (n < 0) return;
+
+    uint8_t header[3] = {(uint8_t)RowBrokerMsg::FRAME, (uint8_t)(n >> 8), (uint8_t)(n & 0xFF)};
+    write(fd, header, sizeof(header));
+    write(fd, raw, n);
+}

--- a/src/row/src/native/pi_transport_native.h
+++ b/src/row/src/native/pi_transport_native.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "pi_transport.h"
+#include <stdint.h>
+
+// Connects to row-bus-broker (tools/row-bus-broker) as a client, modeling
+// this row controller's slave role on the shared multidrop Row Bus. See
+// row_broker_msg.h for the socket framing.
+class PiTransportNative : public IPiTransport {
+    int     fd = -1;
+    uint8_t row_addr;
+
+    // Read state machine for the broker socket protocol.
+    enum class RxState : uint8_t { TYPE, FRAME_LEN_H, FRAME_LEN_L, FRAME_DATA };
+    RxState  rx_state           = RxState::TYPE;
+    uint16_t rx_frame_len       = 0;
+    uint16_t rx_frame_remaining = 0;
+
+public:
+    explicit PiTransportNative(uint8_t row_addr); // 0x00-0x07
+
+    void init() override;  // connect to /tmp/df2-row-bus.sock, IDENTIFY(row_addr)
+    bool poll(RowBusFrameParser &parser, RowBusFrame *out) override;
+    void send(const RowBusFrame &frame) override;
+};

--- a/src/row/src/native/row_broker_msg.h
+++ b/src/row/src/native/row_broker_msg.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <stdint.h>
+
+// Socket framing between row controllers/mock-Pi and row-bus-broker.
+// Every message on the socket starts with a 1-byte type, followed by a
+// type-specific payload.
+//
+//  FRAME     0x01  [len_h:1] [len_l:1] [frame bytes:len]  — raw Row Bus frame
+//  IDENTIFY  0x02  [row_addr:1]                           — sent once on connect
+//
+// RowBusFrame is up to ROWBUS_MAX_FRAME (976) bytes, so FRAME needs a 2-byte
+// length prefix - unlike tile_bus_protocol's broker_msg.h, which fits its
+// 127-byte MAX_FRAME_SIZE in one byte.
+//
+// Row Bus has no SENSE sideband (row addresses are static, no auto-mapping),
+// so unlike broker_msg.h there are no SENSE_* message types here.
+//
+// row_addr identifies the client: 0x00-0x07 for a row controller, 0xFF for
+// the Pi (mock-Pi test driver). The broker itself doesn't interpret this
+// value - it's carried only for logging - since routing is full broadcast
+// and each client filters by ADDR itself, exactly as real RS-485 hardware
+// would.
+
+enum class RowBrokerMsg : uint8_t {
+    FRAME    = 0x01,
+    IDENTIFY = 0x02,
+};

--- a/src/row/test/integration/test_row_bus_broadcast.py
+++ b/src/row/test/integration/test_row_bus_broadcast.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Integration test: Row Bus multidrop relay (row-bus-broker + PiTransportNative).
+
+Starts row-bus-broker and 8 row-stub processes (one per row address 0x00-
+0x07), then acts as a mock Pi: connects to the same broker socket and
+exercises the broker's broadcast-and-local-filter model, mirroring how
+test_sense_mapping.py drives the tile project's tile-bus-broker.
+
+Verifies:
+  - Broadcasting STATUS (addr=0xFF) reaches all 8 row-stubs, each replying
+    with its own STATUS_RESP, distinguishable by ADDR.
+  - Unicasting STATUS to a single row address is answered only by that row,
+    not the other 7 - proving the broker relays to everyone and each client
+    filters locally, like real RS-485 multidrop, not point-to-point.
+
+Always rebuilds tools/bin/{row-bus-broker,row-stub} first (via `make -C
+tools`) rather than just checking they exist, for the same reason
+test_native_discovery.py always rebuilds: a stale binary left over from a
+previous build can silently masquerade as current.
+
+Usage:
+  python3 test/integration/test_row_bus_broadcast.py
+"""
+
+import os
+import sys
+import time
+import socket
+import select
+import subprocess
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+_HERE    = os.path.dirname(os.path.abspath(__file__))
+_PROJECT = os.path.abspath(os.path.join(_HERE, '..', '..'))
+TOOLS    = os.path.join(_PROJECT, 'tools')
+BROKER   = os.path.join(TOOLS, 'bin', 'row-bus-broker')
+STUB     = os.path.join(TOOLS, 'bin', 'row-stub')
+SOCK     = '/tmp/df2-row-bus.sock'
+
+ROWS = list(range(8))  # row addresses 0x00-0x07
+
+# ---------------------------------------------------------------------------
+# Protocol constants (mirrors row_broker_msg.h / row_bus_protocol.h)
+# ---------------------------------------------------------------------------
+SYNC1 = 0xAA
+SYNC2 = 0x55
+ADDR_BROADCAST = 0xFF
+
+CMD_STATUS      = 0x02
+CMD_STATUS_RESP = 0x82
+
+MSG_FRAME    = 0x01
+MSG_IDENTIFY = 0x02
+
+# ---------------------------------------------------------------------------
+# Row Bus frame helpers (2-byte LEN, unlike tile_bus_protocol's 1-byte LEN)
+# ---------------------------------------------------------------------------
+def _crc16(data: bytes) -> int:
+    crc = 0xFFFF
+    for b in data:
+        crc ^= b << 8
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x1021) if (crc & 0x8000) else (crc << 1)
+        crc &= 0xFFFF
+    return crc
+
+def _encode(addr: int, cmd: int, payload: bytes = b'') -> bytes:
+    body = bytes([addr, cmd, len(payload) >> 8, len(payload) & 0xFF]) + payload
+    c = _crc16(body)
+    return bytes([SYNC1, SYNC2]) + body + bytes([c >> 8, c & 0xFF])
+
+def _decode(raw: bytes) -> dict | None:
+    if len(raw) < 8 or raw[0] != SYNC1 or raw[1] != SYNC2:
+        return None
+    addr, cmd = raw[2], raw[3]
+    plen = (raw[4] << 8) | raw[5]
+    if len(raw) != 8 + plen:
+        return None
+    payload = raw[6:6 + plen]
+    expected = _crc16(raw[2:6 + plen])
+    received = (raw[6 + plen] << 8) | raw[7 + plen]
+    if expected != received:
+        return None
+    return {'addr': addr, 'cmd': cmd, 'payload': bytes(payload)}
+
+# ---------------------------------------------------------------------------
+# Mock-Pi connection to the broker
+# ---------------------------------------------------------------------------
+class MockPi:
+    """Speaks the broker socket protocol as the Pi (row_addr=0xFF sentinel)."""
+
+    def __init__(self, sock_path: str):
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.connect(sock_path)
+        self._buf = b''
+        self._sock.sendall(bytes([MSG_IDENTIFY, ADDR_BROADCAST]))
+
+    def send(self, addr: int, cmd: int, payload: bytes = b''):
+        raw = _encode(addr, cmd, payload)
+        n = len(raw)
+        self._sock.sendall(bytes([MSG_FRAME, n >> 8, n & 0xFF]) + raw)
+
+    def recv_all(self, timeout: float) -> list[dict]:
+        """Collect every Row Bus frame that arrives within timeout."""
+        frames = []
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            r, _, _ = select.select([self._sock], [], [], remaining)
+            if not r:
+                break
+            chunk = self._sock.recv(4096)
+            if not chunk:
+                raise ConnectionError('broker disconnected')
+            self._buf += chunk
+            frames.extend(self._drain())
+        return frames
+
+    def _drain(self) -> list[dict]:
+        out = []
+        while self._buf:
+            if self._buf[0] != MSG_FRAME:
+                self._buf = self._buf[1:]  # unknown type, skip
+                continue
+            if len(self._buf) < 3:
+                break
+            n = (self._buf[1] << 8) | self._buf[2]
+            if len(self._buf) < 3 + n:
+                break
+            frame_raw = self._buf[3:3 + n]
+            self._buf = self._buf[3 + n:]
+            decoded = _decode(frame_raw)
+            if decoded:
+                out.append(decoded)
+        return out
+
+    def close(self):
+        self._sock.close()
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+RESPONSE_TIMEOUT = 0.5  # seconds to collect replies
+
+def run_test() -> bool:
+    pi = MockPi(SOCK)
+    failures: list[str] = []
+
+    # ---- Broadcast STATUS: all 8 rows should reply ----
+    print('[Pi] STATUS broadcast (addr=0xFF)')
+    pi.send(ADDR_BROADCAST, CMD_STATUS)
+    frames = pi.recv_all(RESPONSE_TIMEOUT)
+    replies = {f['addr'] for f in frames if f['cmd'] == CMD_STATUS_RESP}
+    print(f'  replies from: {sorted(hex(a) for a in replies)}')
+
+    missing = set(ROWS) - replies
+    extra = replies - set(ROWS)
+    if missing:
+        failures.append(f'broadcast: no reply from row(s) {sorted(hex(a) for a in missing)}')
+    if extra:
+        failures.append(f'broadcast: unexpected reply from {sorted(hex(a) for a in extra)}')
+
+    # ---- Unicast STATUS to row 0x03: only that row should reply ----
+    target = 0x03
+    print(f'[Pi] STATUS unicast -> 0x{target:02X}')
+    pi.send(target, CMD_STATUS)
+    frames = pi.recv_all(RESPONSE_TIMEOUT)
+    replies = {f['addr'] for f in frames if f['cmd'] == CMD_STATUS_RESP}
+    print(f'  replies from: {sorted(hex(a) for a in replies)}')
+
+    if replies != {target}:
+        failures.append(f'unicast to 0x{target:02X}: expected reply only from that row, got {sorted(hex(a) for a in replies)}')
+
+    pi.close()
+
+    print()
+    if failures:
+        for msg in failures:
+            print(f'  FAIL: {msg}')
+        return False
+
+    print('  PASS')
+    return True
+
+
+def main() -> int:
+    print('Building row-bus-broker and row-stub...')
+    result = subprocess.run(['make'], cwd=TOOLS)
+    if result.returncode != 0:
+        print('ERROR: build failed')
+        return 1
+    for path in (BROKER, STUB):
+        if not os.path.isfile(path):
+            print(f'ERROR: binary not found after build: {path}')
+            return 1
+
+    procs: list[subprocess.Popen] = []
+    try:
+        procs.append(subprocess.Popen(
+            [BROKER], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        ))
+        time.sleep(0.15)  # wait for the Unix socket to be created
+
+        for row in ROWS:
+            procs.append(subprocess.Popen(
+                [STUB, str(row)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            ))
+
+        time.sleep(0.5)  # let all stubs connect and identify
+
+        passed = run_test()
+        return 0 if passed else 1
+
+    finally:
+        for p in procs:
+            p.terminate()
+        for p in procs:
+            try:
+                p.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                p.kill()
+        try:
+            os.unlink(SOCK)
+        except FileNotFoundError:
+            pass
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/row/tools/Makefile
+++ b/src/row/tools/Makefile
@@ -1,0 +1,28 @@
+CXX      := g++
+CXXFLAGS := -std=c++17 -Wall -Wextra \
+            -I../include \
+            -I../lib/row_core \
+            -I../src/native
+
+BIN := bin
+
+.PHONY: all clean
+
+all: $(BIN)/row-bus-broker $(BIN)/row-stub
+
+$(BIN):
+	mkdir -p $(BIN)
+
+# The broker only needs row_bus_protocol.h for ROWBUS_MAX_FRAME; it doesn't
+# parse frames itself so no .cpp lib files are required.
+$(BIN)/row-bus-broker: row-bus-broker/main.cpp | $(BIN)
+	$(CXX) $(CXXFLAGS) $< -o $@
+
+# row-stub links PiTransportNative + its row_bus_protocol.cpp dependency
+# directly (not via PlatformIO) since it's a test-only tool, not shipped
+# firmware.
+$(BIN)/row-stub: row-stub/main.cpp ../src/native/pi_transport_native.cpp ../lib/row_core/row_bus_protocol.cpp | $(BIN)
+	$(CXX) $(CXXFLAGS) $^ -o $@
+
+clean:
+	rm -rf $(BIN)

--- a/src/row/tools/bin/.gitignore
+++ b/src/row/tools/bin/.gitignore
@@ -1,0 +1,2 @@
+row-bus-broker
+row-stub

--- a/src/row/tools/row-bus-broker/main.cpp
+++ b/src/row/tools/row-bus-broker/main.cpp
@@ -1,0 +1,210 @@
+// row-bus-broker: models the shared RS-485 multidrop Row Bus as a Unix
+// socket.
+//
+// Up to 9 clients connect (8 row controllers + 1 mock Pi). Every Row Bus
+// frame received from any client is forwarded to all OTHER clients,
+// mirroring RS-485 broadcast. Each client filters by ADDR itself, exactly
+// as real hardware would - the broker does no address-based routing.
+//
+// Row Bus has no SENSE sideband (row addresses are static, no auto-mapping),
+// so unlike tile_bus_protocol's tile-bus-broker this is plain frame relay
+// only.
+//
+// Usage: row-bus-broker
+//   Listens on /tmp/df2-row-bus.sock
+
+#include <array>
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cerrno>
+#include <csignal>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/select.h>
+
+#include "row_broker_msg.h"
+#include "row_bus_protocol.h"
+
+static constexpr int MAX_CLIENTS = 9;
+static constexpr const char *SOCK_PATH = "/tmp/df2-row-bus.sock";
+
+// SIGINT/SIGTERM (e.g. the test harness terminating this process) should
+// still clean up the socket file rather than leaving a stale one behind.
+static void handle_signal(int) {
+    unlink(SOCK_PATH);
+    _exit(0);
+}
+
+struct Client {
+    int     fd         = -1;
+    uint8_t row_addr   = 0xFF;
+    bool    identified = false;
+
+    enum class State : uint8_t { TYPE, FRAME_LEN_H, FRAME_LEN_L, FRAME_DATA, IDENT_ADDR };
+    State    state     = State::TYPE;
+    uint8_t  frame_buf[ROWBUS_MAX_FRAME]{};
+    uint16_t frame_len = 0;
+    uint16_t frame_idx = 0;
+
+    bool active() const { return fd >= 0; }
+    void reset() { *this = Client{}; }
+};
+
+static std::array<Client, MAX_CLIENTS> clients;
+
+static void send_to(int fd, const uint8_t *data, int len) {
+    while (len > 0) {
+        ssize_t n = write(fd, data, len);
+        if (n <= 0) return;
+        data += n;
+        len  -= n;
+    }
+}
+
+static void broadcast_frame(int sender_idx) {
+    Client &s = clients[sender_idx];
+    uint8_t header[3] = {
+        (uint8_t)RowBrokerMsg::FRAME,
+        (uint8_t)(s.frame_len >> 8),
+        (uint8_t)(s.frame_len & 0xFF),
+    };
+    for (int i = 0; i < MAX_CLIENTS; i++) {
+        if (i == sender_idx || !clients[i].active()) continue;
+        send_to(clients[i].fd, header, sizeof(header));
+        send_to(clients[i].fd, s.frame_buf, s.frame_len);
+    }
+}
+
+// Returns false if the client has disconnected.
+static bool process_byte(int idx, uint8_t byte) {
+    Client &c = clients[idx];
+    switch (c.state) {
+    case Client::State::TYPE:
+        switch (static_cast<RowBrokerMsg>(byte)) {
+        case RowBrokerMsg::FRAME:
+            c.state     = Client::State::FRAME_LEN_H;
+            c.frame_idx = 0;
+            break;
+        case RowBrokerMsg::IDENTIFY:
+            c.state = Client::State::IDENT_ADDR;
+            break;
+        default:
+            break;
+        }
+        break;
+
+    case Client::State::FRAME_LEN_H:
+        c.frame_len = (uint16_t)(byte << 8);
+        c.state     = Client::State::FRAME_LEN_L;
+        break;
+
+    case Client::State::FRAME_LEN_L:
+        c.frame_len |= byte;
+        c.frame_idx  = 0;
+        c.state      = (c.frame_len == 0) ? Client::State::TYPE : Client::State::FRAME_DATA;
+        break;
+
+    case Client::State::FRAME_DATA:
+        if (c.frame_idx < ROWBUS_MAX_FRAME) c.frame_buf[c.frame_idx] = byte;
+        if (++c.frame_idx >= c.frame_len) {
+            broadcast_frame(idx);
+            c.state = Client::State::TYPE;
+        }
+        break;
+
+    case Client::State::IDENT_ADDR:
+        c.row_addr   = byte;
+        c.identified = true;
+        c.state      = Client::State::TYPE;
+        printf("[broker] client fd=%d  row_addr=0x%02X\n", c.fd, c.row_addr);
+        fflush(stdout);
+        break;
+    }
+    return true;
+}
+
+// Drain all available bytes from a client. Returns false if disconnected.
+static bool drain_client(int idx) {
+    uint8_t byte;
+    while (true) {
+        ssize_t n = recv(clients[idx].fd, &byte, 1, MSG_DONTWAIT);
+        if (n == 1) {
+            process_byte(idx, byte);
+        } else if (n == 0) {
+            return false; // peer closed
+        } else {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return true;
+            return false; // error
+        }
+    }
+}
+
+int main() {
+    signal(SIGINT, handle_signal);
+    signal(SIGTERM, handle_signal);
+
+    unlink(SOCK_PATH); // clear stale socket from a previous run
+
+    int server_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (server_fd < 0) { perror("socket"); return 1; }
+
+    struct sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+    if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) { perror("bind"); return 1; }
+    if (listen(server_fd, MAX_CLIENTS) < 0) { perror("listen"); return 1; }
+
+    printf("[broker] listening on %s\n", SOCK_PATH);
+    fflush(stdout);
+
+    while (true) {
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(server_fd, &rfds);
+        int max_fd = server_fd;
+
+        for (auto &c : clients) {
+            if (c.active()) {
+                FD_SET(c.fd, &rfds);
+                max_fd = std::max(max_fd, c.fd);
+            }
+        }
+
+        if (select(max_fd + 1, &rfds, nullptr, nullptr, nullptr) < 0) {
+            if (errno == EINTR) continue;
+            perror("select");
+            return 1;
+        }
+
+        // Accept new connections
+        if (FD_ISSET(server_fd, &rfds)) {
+            int new_fd = accept(server_fd, nullptr, nullptr);
+            if (new_fd >= 0) {
+                bool added = false;
+                for (auto &c : clients) {
+                    if (!c.active()) { c.fd = new_fd; added = true; break; }
+                }
+                if (!added) {
+                    fprintf(stderr, "[broker] max clients reached, rejecting fd=%d\n", new_fd);
+                    close(new_fd);
+                }
+            }
+        }
+
+        // Service connected clients
+        for (int i = 0; i < MAX_CLIENTS; i++) {
+            Client &c = clients[i];
+            if (!c.active() || !FD_ISSET(c.fd, &rfds)) continue;
+            if (!drain_client(i)) {
+                printf("[broker] client fd=%d row_addr=0x%02X disconnected\n", c.fd, c.row_addr);
+                fflush(stdout);
+                close(c.fd);
+                c.reset();
+            }
+        }
+    }
+}

--- a/src/row/tools/row-stub/main.cpp
+++ b/src/row/tools/row-stub/main.cpp
@@ -1,0 +1,48 @@
+// row-stub: a minimal Row Bus client used only to test row-bus-broker +
+// PiTransportNative's multidrop relay/filtering. It answers STATUS with a
+// STATUS_RESP carrying its own row address in the payload (state=idle,
+// discovered_count=0, all slots NOT_DISCOVERED) so a test driver can tell
+// which of several connected stubs replied - it does not run real
+// RowCommandHandler dispatch (that's already covered by #30's own tests).
+//
+// Usage: row-stub <row-addr>
+//   row-addr  hex or decimal row address (0x00-0x07)
+
+#include <cstdio>
+#include <cstdlib>
+#include <unistd.h>
+#include "pi_transport_native.h"
+#include "row_bus_protocol.h"
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <row-addr>\n", argv[0]);
+        return 1;
+    }
+    uint8_t row_addr = (uint8_t)strtoul(argv[1], nullptr, 0);
+
+    PiTransportNative transport(row_addr);
+    transport.init();
+
+    printf("[row-stub 0x%02X] ready\n", row_addr);
+    fflush(stdout);
+
+    RowBusFrameParser parser;
+    RowBusFrame        in;
+    while (true) {
+        while (transport.poll(parser, &in)) {
+            if (in.addr != row_addr && in.addr != ROWBUS_ADDR_BROADCAST) continue;
+            if ((RowBusCmd)in.cmd != RowBusCmd::STATUS) continue;
+
+            RowBusFrame resp{};
+            resp.addr = row_addr;
+            resp.cmd  = (uint8_t)RowBusCmd::STATUS_RESP;
+            resp.len  = 10;
+            resp.payload[0] = 0x00; // state: idle
+            resp.payload[1] = 0x00; // discovered_count: 0
+            for (int slot = 0; slot < 8; slot++) resp.payload[2 + slot] = 0x00;
+            transport.send(resp);
+        }
+        usleep(100); // 100 us yield between poll bursts
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `row-bus-broker` (`tools/row-bus-broker/`), a Unix-socket multidrop relay modeling the Pi <-> 8-row-controller Row Bus segment, the same way `tile-bus-broker` models Tile Bus - full broadcast to every other connected client, no address-based routing (real RS-485 doesn't do that either; each client filters by `ADDR` itself)
- No SENSE sideband needed (Row Bus addresses are static, no auto-mapping), so this is simpler than `tile-bus-broker`: plain `FRAME`/`IDENTIFY` relay only (`row_broker_msg.h`), with a 2-byte length prefix since `RowBusFrame`'s 968-byte max payload doesn't fit `tile_bus_protocol`'s 1-byte framing
- Adds `PiTransportNative`, which connects to the broker as a client and identifies with its row address, structurally mirroring `TileTransportNative`
- Broker cleans up its socket file on `SIGINT`/`SIGTERM`, not just at startup (unlike `tile-bus-broker`, which relies on the caller for that)

## Test plan
- [x] `pio run -e native` builds `pi_transport_native.cpp` with no Arduino/RP2350 headers
- [x] All 6 PlatformIO environments build; `pio test -e native`: 36/36 test cases pass (unaffected)
- [x] New `test/integration/test_row_bus_broadcast.py`: starts the broker + 8 `row-stub` processes (one per row address) + a Python mock-Pi driver
  - Broadcasting `STATUS` (`addr=0xFF`) reaches all 8 stubs, each replying with its own address
  - Unicasting `STATUS` to a single row address is answered only by that row, not the other 7 - verifies the broker's relay-and-local-filter model behaves like real multidrop, not point-to-point
  - Socket file confirmed removed after the broker is terminated
- [x] `test/integration/test_native_discovery.py` (unrelated Tile Bus test) still passes, confirming no regression

Closes #33