### PR TITLE
[Row Controller] Land #45's dual-core main.cpp onto main

### DIFF
--- a/src/row/src/main.cpp
+++ b/src/row/src/main.cpp
@@ -1,14 +1,74 @@
 #include <Arduino.h>
 #include "rp2350/pins.h"
 #include "row_address_generated.h"
+#include "rp2350/pi_transport_rp2350.h"
+#include "rp2350/tile_transport_rp2350.h"
+#include "rp2350/row_sense_rp2350.h"
+#include "rp2350/power_monitor_rp2350.h"
+#include "rp2350/row_bus_frame_queue.h"
+#include "sense_mapper.h"
+#include "row_command_handler.h"
+
+// Core 0 - Row Bus ingest: owns PiTransportRP2350, validates and address-
+// filters incoming frames, forwards responses back out over Row Bus.
+// Core 1 - Tile Bus egress + dispatch: owns everything Tile-Bus-facing and
+// SenseMapper, consumes frames handed off from core 0 via RowCommandHandler.
+//
+// Global objects are constructed (by normal C++ static init) before either
+// core's setup()/setup1() runs - see framework-arduinopico's main(), which
+// launches core 1 only after core 0's static init and USB/serial bring-up -
+// so both cores always see fully-constructed queues/objects, no lazy-init
+// ordering to worry about.
+
+static PiTransportRP2350   pi_transport;
+static TileTransportRP2350 tile_transport;
+static RowSenseRP2350      row_sense;
+static PowerMonitorRP2350  power_monitor;
+static TileMap             tile_map;
+static SenseMapper         sense_mapper(tile_transport, row_sense, tile_map);
+static RowCommandHandler   row_cmd_handler(tile_transport, sense_mapper, power_monitor, MY_ROW_ADDR);
+
+// core 0 -> core 1: validated (CRC-good, addressed to us or broadcast) frames
+static RowBusFrameQueue ingest_queue;
+// core 1 -> core 0: RowCommandHandler responses to admin commands, bound for the Pi
+static RowBusFrameQueue response_queue;
+
+// ---- Core 0 : Row Bus ingest ----
 
 void setup() {
-    Serial.begin(115200);
+    pi_transport.init();
 }
 
 void loop() {
-    Serial.print("row controller: not yet implemented (row address 0x");
-    Serial.print(MY_ROW_ADDR, HEX);
-    Serial.println(")");
-    delay(1000);
+    static RowBusFrameParser parser;
+    RowBusFrame frame;
+
+    while (pi_transport.poll(parser, &frame)) {
+        if (frame.addr != MY_ROW_ADDR && frame.addr != ROWBUS_ADDR_BROADCAST) continue;
+        ingest_queue.try_push(frame); // dropped if core 1 has fallen behind
+    }
+
+    RowBusFrame response;
+    while (response_queue.try_pop(&response)) {
+        pi_transport.send(response);
+    }
+}
+
+// ---- Core 1 : Tile Bus egress + dispatch ----
+
+void setup1() {
+    tile_transport.init();
+    row_sense.init();
+    power_monitor.init();
+    sense_mapper.start();
+}
+
+void loop1() {
+    sense_mapper.poll(millis());
+
+    RowBusFrame frame;
+    while (ingest_queue.try_pop(&frame)) {
+        const RowBusFrame *response = row_cmd_handler.handle(frame);
+        if (response) response_queue.try_push(*response);
+    }
 }

--- a/src/row/src/rp2350/row_bus_frame_queue.h
+++ b/src/row/src/rp2350/row_bus_frame_queue.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <pico/mutex.h>
+#include "row_bus_protocol.h"
+
+// Fixed-capacity, mutex-guarded ring buffer for handing RowBusFrame values
+// between the RP2350's two cores (#45). One instance per direction - this
+// is not a general-purpose multi-producer queue, just a small SPSC handoff.
+//
+// A pico_util queue_t (pico/util/queue.h) would do this job too, but it
+// calloc()s its backing storage at init time; this project keeps everything
+// statically sized (no dynamic allocation anywhere, see TileMap etc.), so
+// this uses a fixed member array instead.
+class RowBusFrameQueue {
+public:
+    static constexpr uint8_t CAPACITY = 4;
+
+    RowBusFrameQueue() { mutex_init(&mutex_); }
+
+    // Returns false (frame dropped) if the queue is full.
+    bool try_push(const RowBusFrame &frame) {
+        mutex_enter_blocking(&mutex_);
+        bool ok = count_ < CAPACITY;
+        if (ok) {
+            slots_[head_] = frame;
+            head_ = (uint8_t)((head_ + 1) % CAPACITY);
+            count_++;
+        }
+        mutex_exit(&mutex_);
+        return ok;
+    }
+
+    // Returns false if the queue is empty.
+    bool try_pop(RowBusFrame *out) {
+        mutex_enter_blocking(&mutex_);
+        bool ok = count_ > 0;
+        if (ok) {
+            *out = slots_[tail_];
+            tail_ = (uint8_t)((tail_ + 1) % CAPACITY);
+            count_--;
+        }
+        mutex_exit(&mutex_);
+        return ok;
+    }
+
+private:
+    mutex_t     mutex_;
+    RowBusFrame slots_[CAPACITY]{};
+    uint8_t     head_  = 0;
+    uint8_t     tail_  = 0;
+    uint8_t     count_ = 0;
+};


### PR DESCRIPTION
## Summary

PR #52 (closing #45) was stacked on `feature/#50-row-address-chipid-mapping` for a legitimate reason (it depends on that branch's generated header), but PR #51 (that same branch) merged into `main` a minute *before* #52 merged into it. Nobody opened a follow-up PR to bring the updated branch back into `main`, so #45's actual commit ([f800503](https://github.com/tennessee-garage/dance-more/commit/f800503)) never landed there, even though both issues show as closed on GitHub (the PR did merge successfully - just not into the default branch, so GitHub's auto-close fired without the code actually reaching `main`).

This PR is just that missing merge - one commit, no new changes:
- `src/main.cpp`: the dual-core wiring (Row Bus ingest on core 0 / Tile Bus egress on core 1)
- `src/rp2350/row_bus_frame_queue.h`: the mutex-guarded cross-core handoff queue

## Test plan
- [x] `pio run` (all 6 environments) and `pio test -e native` (36/36) pass on this branch, same as verified when #52 was reviewed