### PR TITLE
[Row Controller] LATCH overrun buffering + ERROR_LOG producer

### DIFF
--- a/src/row/lib/row_core/row_command_handler.cpp
+++ b/src/row/lib/row_core/row_command_handler.cpp
@@ -68,45 +68,107 @@ void RowCommandHandler::handle_re_discover() {
     response_.payload[0] = 0x00; // started
 }
 
-// Stub: the 32-entry ring buffer this needs doesn't have a producer yet -
-// wire this up once Tile Bus retry logic exists in concrete transports.
 void RowCommandHandler::handle_error_log() {
     response_.addr = my_row_addr_;
     response_.cmd  = (uint8_t)RowBusCmd::ERROR_LOG_RESP;
-    response_.len  = 1;
-    response_.payload[0] = 0x00; // entry_count
-}
+    response_.len  = (uint16_t)(1 + error_log_count_ * 5);
+    response_.payload[0] = error_log_count_;
 
-void RowCommandHandler::handle_send_data(const RowBusFrame &in) {
-    const TileMap &map = sense_.result();
-    uint16_t offset = 0;
-
-    for (uint8_t slot = 0; slot < TileMap::NUM_SLOTS; slot++) {
-        if (offset >= in.len) break; // short/malformed frame - stop rather than read garbage
-
-        uint8_t tile_cmd = in.payload[offset];
-        uint8_t data_len;
-        switch ((Cmd)tile_cmd) {
-        case Cmd::SET_COLOR:   data_len = 3;   break;
-        case Cmd::SET_PATTERN: data_len = 5;   break;
-        case Cmd::SET_LEDS:    data_len = 120; break;
-        default: return; // unrecognized tile_cmd - can't know its size, stop parsing
-        }
-
-        if (map.is_discovered(slot))
-            send_tile_frame(map.address_for(slot), (Cmd)tile_cmd, &in.payload[offset + 1], data_len);
-        // else: slot not discovered - skip forwarding, still advance offset below
-
-        offset = (uint16_t)(offset + 1 + data_len);
+    // Oldest first: if the buffer hasn't wrapped yet, entry 0 is oldest and
+    // sits at index 0; once full, the oldest is whatever error_log_next_ is
+    // about to overwrite.
+    uint8_t start = (error_log_count_ == ERROR_LOG_CAPACITY) ? error_log_next_ : 0;
+    for (uint8_t i = 0; i < error_log_count_; i++) {
+        const ErrorLogEntry &e = error_log_[(start + i) % ERROR_LOG_CAPACITY];
+        uint8_t *p = &response_.payload[1 + i * 5];
+        p[0] = e.slot;
+        p[1] = e.tile_bus_cmd;
+        p[2] = e.error_type;
+        p[3] = (uint8_t)(e.timestamp_s >> 8);
+        p[4] = (uint8_t)(e.timestamp_s & 0xFF);
     }
 }
 
-// TODO(#46): overrun buffering - defer this LATCH if still forwarding a
-// SEND_DATA that hasn't finished, per docs/row-bus-protocol.md's
-// LATCH_OVERRUN handling. Not tracked yet; needs real Tile Bus forwarding
-// timing to design against.
-void RowCommandHandler::handle_latch() {
+void RowCommandHandler::log_error(uint8_t slot, uint8_t tile_bus_cmd, uint8_t error_type, uint32_t now_ms) {
+    ErrorLogEntry &e = error_log_[error_log_next_];
+    e.slot         = slot;
+    e.tile_bus_cmd = tile_bus_cmd;
+    e.error_type   = error_type;
+    e.timestamp_s  = (uint16_t)(now_ms / 1000);
+
+    error_log_next_ = (uint8_t)((error_log_next_ + 1) % ERROR_LOG_CAPACITY);
+    if (error_log_count_ < ERROR_LOG_CAPACITY) error_log_count_++;
+}
+
+bool RowCommandHandler::parse_entry(uint16_t offset, uint8_t *tile_cmd_out, uint8_t *data_len_out) const {
+    if (offset >= forwarding_frame_.len) return false; // short/malformed frame
+
+    uint8_t tile_cmd = forwarding_frame_.payload[offset];
+    uint8_t data_len;
+    switch ((Cmd)tile_cmd) {
+    case Cmd::SET_COLOR:   data_len = 3;   break;
+    case Cmd::SET_PATTERN: data_len = 5;   break;
+    case Cmd::SET_LEDS:    data_len = 120; break;
+    default: return false; // unrecognized tile_cmd - can't know its size
+    }
+
+    *tile_cmd_out = tile_cmd;
+    *data_len_out = data_len;
+    return true;
+}
+
+void RowCommandHandler::handle_send_data(const RowBusFrame &in) {
+    // Starts (or restarts) incremental forwarding; poll() advances it one
+    // slot per call. The protocol doesn't allow a second SEND_DATA to the
+    // same row before the frame's LATCH, so re-entry here just restarts.
+    forwarding_frame_ = in;
+    forward_offset_   = 0;
+    forward_slot_     = 0;
+    forwarding_       = true;
+    latch_deferred_   = false;
+}
+
+void RowCommandHandler::advance_forwarding() {
+    uint8_t tile_cmd, data_len;
+    if (forward_slot_ >= TileMap::NUM_SLOTS || !parse_entry(forward_offset_, &tile_cmd, &data_len)) {
+        finish_forwarding();
+        return;
+    }
+
+    const TileMap &map = sense_.result();
+    if (map.is_discovered(forward_slot_))
+        send_tile_frame(map.address_for(forward_slot_), (Cmd)tile_cmd,
+                         &forwarding_frame_.payload[forward_offset_ + 1], data_len);
+    // else: slot not discovered - skip forwarding, still advance below
+
+    forward_offset_ = (uint16_t)(forward_offset_ + 1 + data_len);
+    forward_slot_++;
+
+    if (forward_slot_ >= TileMap::NUM_SLOTS || forward_offset_ >= forwarding_frame_.len) finish_forwarding();
+}
+
+void RowCommandHandler::finish_forwarding() {
+    forwarding_ = false;
+    if (!latch_deferred_) return;
+
+    latch_deferred_ = false;
     broadcast_tile_latch();
+    log_error(overrun_slot_, overrun_tile_cmd_, ERROR_TYPE_LATCH_OVERRUN, last_now_ms_);
+}
+
+void RowCommandHandler::handle_latch() {
+    if (!forwarding_) {
+        broadcast_tile_latch();
+        return;
+    }
+
+    // Still forwarding SEND_DATA: buffer this LATCH per docs/row-bus-protocol.md's
+    // overrun handling - finish forwarding (poll() drives that), then fire it.
+    latch_deferred_ = true;
+    overrun_slot_   = forward_slot_;
+
+    uint8_t tile_cmd, data_len;
+    overrun_tile_cmd_ = parse_entry(forward_offset_, &tile_cmd, &data_len) ? tile_cmd : 0x00;
 }
 
 void RowCommandHandler::handle_blackout() {
@@ -118,6 +180,11 @@ void RowCommandHandler::handle_blackout() {
         send_tile_frame(map.address_for(slot), Cmd::SET_COLOR, black, sizeof(black));
     }
     broadcast_tile_latch();
+}
+
+void RowCommandHandler::poll(uint32_t now_ms) {
+    last_now_ms_ = now_ms;
+    if (forwarding_) advance_forwarding();
 }
 
 const RowBusFrame *RowCommandHandler::handle(const RowBusFrame &in) {

--- a/src/row/lib/row_core/row_command_handler.h
+++ b/src/row/lib/row_core/row_command_handler.h
@@ -5,6 +5,23 @@
 #include "sense_mapper.h"
 #include "../../include/power_monitor.h"
 
+// One entry in the error log ring buffer (docs/row-bus-protocol.md §5.1's
+// ERROR_LOG_RESP payload format). For LATCH_OVERRUN entries the fields are
+// repurposed per that doc: slot = number of tile slots forwarded when LATCH
+// arrived, tile_bus_cmd = the tile command that was in flight at the time.
+struct ErrorLogEntry {
+    uint8_t  slot;
+    uint8_t  tile_bus_cmd;
+    uint8_t  error_type;
+    uint16_t timestamp_s;
+};
+
+// error_type values (docs/row-bus-protocol.md §5.1). Only LATCH_OVERRUN has
+// a producer so far - the others describe future error sources (SenseMapper
+// retry exhaustion, CRC failures, sense collisions) with nothing wired up
+// to log them yet.
+static constexpr uint8_t ERROR_TYPE_LATCH_OVERRUN = 0x04;
+
 // Dispatches Row Bus commands arriving from the Raspberry Pi
 // (docs/row-bus-protocol.md §5). in.addr must already be filtered by the
 // caller (== my_row_addr or broadcast).
@@ -17,7 +34,15 @@ public:
     // if no response is needed (SEND_DATA / LATCH / BLACKOUT).
     const RowBusFrame *handle(const RowBusFrame &in);
 
+    // Advances any in-flight SEND_DATA forwarding by one tile slot. Call
+    // every loop iteration (mirrors SenseMapper::poll()'s convention) -
+    // this is what makes a LATCH arriving mid-forward observable/deferrable
+    // rather than everything completing atomically within handle().
+    void poll(uint32_t now_ms);
+
 private:
+    static constexpr uint8_t ERROR_LOG_CAPACITY = 32;
+
     void handle_test();
     void handle_status();
     void handle_power();
@@ -30,9 +55,34 @@ private:
     void send_tile_frame(uint8_t addr, Cmd cmd, const uint8_t *payload, uint8_t len);
     void broadcast_tile_latch();
 
+    // Per-tile SEND_DATA entry parsing, shared by handle_send_data's
+    // forwarding loop and handle_latch's overrun peek. Returns false if
+    // offset is out of range or the tile_cmd is unrecognized.
+    bool parse_entry(uint16_t offset, uint8_t *tile_cmd_out, uint8_t *data_len_out) const;
+    void advance_forwarding();  // forwards one slot; called from poll()
+    void finish_forwarding();   // fires a deferred LATCH + logs the overrun, if any
+
+    void log_error(uint8_t slot, uint8_t tile_bus_cmd, uint8_t error_type, uint32_t now_ms);
+
     ITransport    &tile_transport_;
     SenseMapper   &sense_;
     IPowerMonitor &power_;
     uint8_t        my_row_addr_;
     RowBusFrame    response_ = {};
+
+    // SEND_DATA forwarding state (#46).
+    bool        forwarding_       = false;
+    RowBusFrame forwarding_frame_ = {};
+    uint16_t    forward_offset_   = 0;
+    uint8_t     forward_slot_     = 0;
+    bool        latch_deferred_   = false;
+    uint8_t     overrun_slot_     = 0;
+    uint8_t     overrun_tile_cmd_ = 0;
+    uint32_t    last_now_ms_      = 0;
+
+    // Error log ring buffer (#46). Oldest entries are overwritten when full;
+    // reading (ERROR_LOG) does not clear it, per docs/row-bus-protocol.md §5.1.
+    ErrorLogEntry error_log_[ERROR_LOG_CAPACITY]{};
+    uint8_t       error_log_count_ = 0; // valid entries, caps at ERROR_LOG_CAPACITY
+    uint8_t       error_log_next_  = 0; // next write index, wraps
 };

--- a/src/row/src/main.cpp
+++ b/src/row/src/main.cpp
@@ -71,4 +71,10 @@ void loop1() {
         const RowBusFrame *response = row_cmd_handler.handle(frame);
         if (response) response_queue.try_push(*response);
     }
+
+    // Advances any in-flight SEND_DATA forwarding by one tile slot. Runs
+    // after draining the queue above so that a LATCH already queued behind
+    // a SEND_DATA in the same batch is dispatched (and, if forwarding isn't
+    // done yet, deferred - see #46) before any slots advance this iteration.
+    row_cmd_handler.poll(millis());
 }

--- a/src/row/test/test_row_command_handler/test_row_command_handler.cpp
+++ b/src/row/test/test_row_command_handler/test_row_command_handler.cpp
@@ -129,6 +129,9 @@ void test_send_data_forwards_mixed_commands_to_correct_addresses() {
     const RowBusFrame *resp = handler.handle(req);
 
     TEST_ASSERT_NULL(resp); // fire-and-forget, no response
+    // handle() only starts forwarding now (#46) - poll() advances one slot
+    // per call, so 8 calls are needed to forward all 8 slots.
+    for (int i = 0; i < 8; i++) handler.poll(0);
     TEST_ASSERT_EQUAL(8, transport.sent.size());
 
     for (uint8_t slot = 0; slot < 7; slot++) {
@@ -169,6 +172,7 @@ void test_send_data_skips_undiscovered_slots() {
     RowCommandHandler handler(transport, sense, power, 0x00);
     RowBusFrame req = make_frame(0x00, RowBusCmd::SEND_DATA, payload, offset);
     handler.handle(req);
+    for (int i = 0; i < 8; i++) handler.poll(0);
 
     // Only slot 0 is discovered, but the parser must still walk all 8
     // fixed-size entries to stay aligned - if offset tracking were wrong,
@@ -231,6 +235,130 @@ void test_blackout_sends_black_to_each_discovered_tile_then_latch() {
 }
 
 // ---------------------------------------------------------------------------
+// LATCH overrun (#46)
+// ---------------------------------------------------------------------------
+
+void test_latch_defers_when_send_data_still_forwarding() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    for (uint8_t i = 0; i < 8; i++) map.set_discovered(i, (uint8_t)(i + 1));
+
+    uint8_t payload[8 * 4] = {};
+    uint16_t offset = 0;
+    for (uint8_t slot = 0; slot < 8; slot++) {
+        payload[offset++] = (uint8_t)Cmd::SET_COLOR;
+        payload[offset++] = 1; payload[offset++] = 2; payload[offset++] = 3;
+    }
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame send_req = make_frame(0x00, RowBusCmd::SEND_DATA, payload, offset);
+    handler.handle(send_req);
+
+    // Advance 3 of 8 slots before LATCH arrives.
+    handler.poll(1000);
+    handler.poll(1000);
+    handler.poll(1000);
+    TEST_ASSERT_EQUAL(3, transport.sent.size());
+
+    RowBusFrame latch_req = make_frame(ROWBUS_ADDR_BROADCAST, RowBusCmd::LATCH, nullptr, 0);
+    const RowBusFrame *latch_resp = handler.handle(latch_req);
+    TEST_ASSERT_NULL(latch_resp);
+
+    // Deferred: no LATCH frame sent yet, forwarding continues untouched.
+    TEST_ASSERT_EQUAL(3, transport.sent.size());
+
+    // Drain the remaining 5 slots.
+    for (int i = 0; i < 5; i++) handler.poll(2000);
+
+    // All 8 tiles forwarded, then exactly one deferred LATCH broadcast.
+    TEST_ASSERT_EQUAL(9, transport.sent.size());
+    const Frame &latch = transport.sent[8];
+    TEST_ASSERT_EQUAL_HEX8(ADDR_BROADCAST, latch.addr);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)Cmd::LATCH, latch.cmd);
+
+    // Overrun logged: 3 slots had been forwarded, slot 3's SET_COLOR was
+    // the in-flight command, timestamped at the poll() call that finished
+    // forwarding (2000ms -> 2s).
+    RowBusFrame log_req = make_frame(0x00, RowBusCmd::ERROR_LOG, nullptr, 0);
+    const RowBusFrame *log_resp = handler.handle(log_req);
+    TEST_ASSERT_NOT_NULL(log_resp);
+    TEST_ASSERT_EQUAL(1 + 5, log_resp->len);
+    TEST_ASSERT_EQUAL(1, log_resp->payload[0]); // entry_count
+    TEST_ASSERT_EQUAL_HEX8(3,                        log_resp->payload[1]); // slot
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)Cmd::SET_COLOR,  log_resp->payload[2]); // tile_bus_cmd
+    TEST_ASSERT_EQUAL_HEX8(0x04,                     log_resp->payload[3]); // error_type: LATCH_OVERRUN
+    TEST_ASSERT_EQUAL_HEX8(0, log_resp->payload[4]); // timestamp high byte
+    TEST_ASSERT_EQUAL_HEX8(2, log_resp->payload[5]); // timestamp low byte: 2000ms -> 2s
+}
+
+void test_latch_without_forwarding_is_unaffected_by_overrun_logic() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    handler.poll(0); // no forwarding in flight - must be a no-op
+
+    RowBusFrame req = make_frame(ROWBUS_ADDR_BROADCAST, RowBusCmd::LATCH, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NULL(resp);
+    TEST_ASSERT_EQUAL(1, transport.sent.size()); // immediate broadcast, same as before #46
+
+    RowBusFrame log_req = make_frame(0x00, RowBusCmd::ERROR_LOG, nullptr, 0);
+    const RowBusFrame *log_resp = handler.handle(log_req);
+    TEST_ASSERT_EQUAL(0, log_resp->payload[0]); // no overrun logged
+}
+
+void test_error_log_ring_buffer_caps_at_32_and_drops_oldest() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+    map.set_discovered(0, 0x01); // slots 1-7 undiscovered, keeps each cycle cheap
+
+    uint8_t payload[8 * 4] = {};
+    uint16_t offset = 0;
+    for (uint8_t slot = 0; slot < 8; slot++) {
+        payload[offset++] = (uint8_t)Cmd::SET_COLOR;
+        payload[offset++] = 0; payload[offset++] = 0; payload[offset++] = 0;
+    }
+
+    RowCommandHandler handler(transport, sense, power, 0x00);
+    RowBusFrame send_req  = make_frame(0x00, RowBusCmd::SEND_DATA, payload, offset);
+    RowBusFrame latch_req = make_frame(ROWBUS_ADDR_BROADCAST, RowBusCmd::LATCH, nullptr, 0);
+
+    // Trigger 33 overruns (one more than the 32-entry capacity), each with a
+    // distinct timestamp, to verify the oldest entry gets dropped.
+    for (uint32_t i = 0; i < 33; i++) {
+        uint32_t now_ms = i * 1000;
+        handler.handle(send_req);
+        handler.poll(now_ms);                            // advance 1 slot, then defer
+        handler.handle(latch_req);
+        for (int s = 0; s < 7; s++) handler.poll(now_ms); // finish the remaining 7 slots
+    }
+
+    RowBusFrame log_req = make_frame(0x00, RowBusCmd::ERROR_LOG, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(log_req);
+    TEST_ASSERT_EQUAL(32, resp->payload[0]);
+    TEST_ASSERT_EQUAL(1 + 32 * 5, resp->len);
+
+    // Oldest (timestamp 0, from i=0) was overwritten; entries are timestamps
+    // 1..32, oldest first.
+    for (int i = 0; i < 32; i++) {
+        uint16_t ts = (uint16_t)((resp->payload[1 + i * 5 + 3] << 8) | resp->payload[1 + i * 5 + 4]);
+        TEST_ASSERT_EQUAL(i + 1, ts);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // RE_DISCOVER / TEST / ERROR_LOG
 // ---------------------------------------------------------------------------
 
@@ -270,7 +398,7 @@ void test_test_command_returns_always_pass_stub() {
     TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[1]);
 }
 
-void test_error_log_returns_empty_stub() {
+void test_error_log_returns_empty_when_no_errors_logged() {
     FakeTileTransport transport;
     FakeRowSense      row_sense;
     TileMap           map;
@@ -299,10 +427,13 @@ int main(int, char **) {
     RUN_TEST(test_send_data_forwards_mixed_commands_to_correct_addresses);
     RUN_TEST(test_send_data_skips_undiscovered_slots);
     RUN_TEST(test_latch_broadcasts_tile_latch);
+    RUN_TEST(test_latch_defers_when_send_data_still_forwarding);
+    RUN_TEST(test_latch_without_forwarding_is_unaffected_by_overrun_logic);
+    RUN_TEST(test_error_log_ring_buffer_caps_at_32_and_drops_oldest);
     RUN_TEST(test_blackout_sends_black_to_each_discovered_tile_then_latch);
     RUN_TEST(test_re_discover_starts_sense_mapping_and_acks);
     RUN_TEST(test_test_command_returns_always_pass_stub);
-    RUN_TEST(test_error_log_returns_empty_stub);
+    RUN_TEST(test_error_log_returns_empty_when_no_errors_logged);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- `RowCommandHandler::handle_send_data()` now only *starts* incremental forwarding; a new `poll(now_ms)` method (called every `loop1()` iteration in [main.cpp](https://github.com/tennessee-garage/dance-more/blob/main/src/row/src/main.cpp), mirroring `SenseMapper::poll()`'s convention) advances exactly one tile slot per call. This is what makes "still forwarding when LATCH arrives" an observable, testable state at all - previously the whole loop completed atomically inside one `handle()` call, so that window never existed.
- `handle_latch()` checks that in-flight state: if forwarding is still running, it defers - recording how many slots had been forwarded and which tile command was next - instead of broadcasting immediately. If nothing is in flight, behavior is unchanged (immediate broadcast).
- `finish_forwarding()` fires the deferred `LATCH` once the last slot completes and appends a `LATCH_OVERRUN` entry (`error_type 0x04`) to a new 32-entry ring-buffer error log, per [row-bus-protocol.md](https://github.com/tennessee-garage/dance-more/blob/main/docs/row-bus-protocol.md)'s repurposed field layout for that entry type.
- `handle_error_log()` now serializes real logged entries (oldest first) in the documented 5-byte-per-entry wire format instead of always reporting zero.

## Test plan
- [x] Updated `test_send_data_*` tests to drive `poll()` to completion (`handle()` only starts forwarding now)
- [x] New: LATCH deferral mid-forward, and its correctly-logged entry (slot count, in-flight tile command, error type, timestamp)
- [x] New: LATCH with nothing in flight is unaffected (still immediate)
- [x] New: error log ring buffer caps at 32 entries and drops the oldest on the 33rd
- [x] `pio run` (all 6 environments) and `pio test -e native`: 39/39 pass

Closes #46