### PR TITLE
Assign tile addresses by position during the SENSE walk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,13 @@ Each is documented where it bites — this is just the index:
 - Branches: `feature/#<issue>-<slug>` where an issue exists.
 - Firmware and host changes that share a protocol behaviour go in **separate
   commits**, one per side.
+- **Bump the firmware version before opening a PR.** Any non-`.md` change under
+  `src/row/` bumps `ROW_FW_VERSION`, under `src/tile/` bumps
+  `TILE_FW_VERSION`, and anything under `src/common/tile_bus_protocol/` bumps
+  **both** — it ships in both images. CI enforces this
+  (`.github/workflows/fw-version-bump.yml`) but only on `pull_request`, so a
+  push straight to `main` slips through and the constants silently stop
+  meaning anything. Gaps are fine; going backwards is not.
 - Row addresses are global `0x00`–`0x07` even though the floor runs two RS-485
   chains; only the wiring is partitioned, and row firmware is unaware of it.
 

--- a/docs/tile-bus-protocol.md
+++ b/docs/tile-bus-protocol.md
@@ -36,7 +36,7 @@ controller or a tile responding to a command.
 | --------- | ---- | ----------- |
 | `SYNC1`   | 1 B  | Always `0xAA`. Marks frame start. |
 | `SYNC2`   | 1 B  | Always `0x55`. Two-byte preamble reduces false-sync probability. |
-| `ADDR`    | 1 B  | Target tile address (`0x01`–`0xFE`), or `0xFF` for broadcast. On response frames this is the responding tile's address. |
+| `ADDR`    | 1 B  | Target tile address (`0x01`–`0x08`, see §3), or `0xFF` for broadcast. On response frames this is the responding tile's address. |
 | `CMD`     | 1 B  | Command or response code (see §5 and §6). |
 | `LEN`     | 1 B  | Number of payload bytes that follow (`0`–`180`). |
 | `PAYLOAD` | N B  | Command-specific data; absent when `LEN = 0`. |
@@ -66,13 +66,35 @@ bytes per LED.
 
 | Range         | Meaning |
 | ------------- | ------- |
-| `0x00`        | Reserved |
-| `0x01`–`0xFE` | Valid tile unicast addresses |
-| `0xFF`        | Broadcast — all tiles accept and process, none respond (except `DETECT_SENSE`) |
+| `0x00`        | Unassigned — a tile that has not yet been given an address |
+| `0x01`–`0x08` | Tile at slot 0–7, assigned during the SENSE walk |
+| `0x09`–`0xFE` | Unused |
+| `0xFF`        | Broadcast — all tiles accept and process, none respond (except `DETECT_SENSE` and `SET_ADDRESS`) |
 
-Each tile's address is **programmed into non-volatile storage at manufacturing
-time** and is unique across all tiles in the system. Address assignment
-procedure: TBD (see §10).
+**Addresses are assigned by position, at every boot, and are not stored.** A
+tile powers up as `0x00` and is named by its row controller during the SENSE
+auto-mapping walk (§9): the tile found at slot *N* becomes address *N+1*.
+
+Two facts make this work, and they are worth stating because the obvious
+reading of "address" suggests otherwise:
+
+- **Addresses need only be unique on one Tile Bus.** The floor's 8 rows are 8
+  electrically separate buses that never join, so 8 addresses suffice for 64
+  tiles. Nothing needs to be unique floor-wide.
+- **Exactly one tile is selected at a time during the walk.** That is what
+  lets a broadcast `SET_ADDRESS` reach precisely one tile, which is the only
+  way to name a tile that has no address to unicast to yet.
+
+The consequences are the point of the scheme: tiles are physically
+interchangeable, a replacement needs no programming before it works, there is
+no manufacturing step and no per-tile firmware build, and the slot→address map
+can never disagree with the physical chain because position *is* the address.
+The cost is that a tile is addressable only after discovery reaches it, and
+that a row controller reset re-runs the walk (which it already did).
+
+An unaddressed tile matches broadcasts only. That is sufficient: `DETECT_SENSE`
+and `SET_ADDRESS`, the two commands it must see before it has a name, are both
+broadcast.
 
 ---
 
@@ -83,6 +105,7 @@ procedure: TBD (see §10).
 | Admin (unicast)  | **Yes** — row controller waits for `ACK` response |
 | Admin (broadcast, no response expected) | No |
 | `DETECT_SENSE` (broadcast, one tile responds) | **Yes** — one tile sends `DETECT_RESP` |
+| `SET_ADDRESS` (broadcast, one tile responds) | **Yes** — one tile sends `0x86`, from its new address |
 | Display (all)    | **No** — fire and forget |
 
 ---
@@ -196,6 +219,41 @@ Response payload (7 bytes, big-endian; shared encoding, defined once in
 | 0–1   | `version` | `TILE_FW_VERSION`, hand-bumped per build |
 | 2–5   | `git_sha` | First 4 bytes of the build's commit SHA |
 | 6     | `flags`   | Bit 0 = built from a dirty tree; bits 1–7 reserved (must be 0) |
+
+---
+
+#### `0x06 SET_ADDRESS` — broadcast
+
+Assigns the addressed-by-position address to the one tile whose incoming
+SENSE line is currently asserted. Sent by the row controller during the SENSE
+walk (§9), immediately after that slot's `DETECT_RESP`.
+
+Broadcast is not a convenience here but a necessity: the target may hold
+`0x00` and so cannot be reached by unicast. The SENSE walk supplies the
+selectivity instead — exactly one tile has its incoming line asserted at any
+point in the walk, and **a tile whose SENSE line is not asserted must ignore
+this command entirely.** Without that rule every tile on the bus would take
+the same address at once.
+
+| Field   | Value |
+| ------- | ----- |
+| `ADDR`  | `0xFF` |
+| `CMD`   | `0x06` |
+| `LEN`   | `1` |
+| Payload | `new_addr` — the address the tile is to adopt |
+| ACK     | **Yes** (`0x86`), **sent from the new address** |
+
+`new_addr` of `0x00` or `0xFF` is invalid and must be ignored; neither is a
+usable unicast address (§3).
+
+The acknowledgement is sent from the newly adopted address, not the old one.
+That is deliberate — it confirms the assignment actually took, where an ACK
+from the previous address would only confirm the command was received. The row
+controller matches on it before recording the slot.
+
+Assignment is a plain overwrite with no notion of "already addressed": a row
+controller that resets mid-show re-walks a chain of tiles that still hold
+their previous names, and must be able to rename them.
 
 ---
 
@@ -329,12 +387,22 @@ to `DETECT_SENSE`.
 
 | Field   | Value |
 | ------- | ----- |
-| `ADDR`  | responding tile's address ← **this is what the row controller captures** |
+| `ADDR`  | responding tile's *current* address — see below |
 | `CMD`   | `0x82` |
 | `LEN`   | `0` |
 | Payload | none |
 
-The tile address is carried in the `ADDR` field; no payload is needed.
+`DETECT_RESP` means "a tile is present at this slot" and nothing more. The
+address it carries is whatever the tile happens to hold — `0x00` on a freshly
+booted tile, a stale assignment on one that survived a row controller reset —
+and **the row controller must not record it.** The slot's address is decided
+by the `SET_ADDRESS` that follows, and confirmed by the `0x86` sent from it.
+
+### `0x86 ACK (SET_ADDRESS)` — tile → row controller
+
+Sent in response to `SET_ADDRESS (0x06)`, **from the newly adopted address**,
+with a 1-byte status payload (`0x00` = success). See §5.1's `SET_ADDRESS`
+entry for why the source address is the meaningful part.
 
 ### `0x85 VERSION_RESP` — tile → row controller
 
@@ -434,23 +502,28 @@ commands used are:
 
 1. Row controller asserts SENSE to tile 0 (hardware line, not a command).
 2. RC → all: `DETECT_SENSE (0x02)` → tile 0 replies `DETECT_RESP (0x82)`.
-   RC records tile 0's address.
-3. RC → tile 0: `ACTIVATE_SENSE (0x01)` → tile 0 pulls its outgoing SENSE low.
-4. RC → all: `DETECT_SENSE (0x02)` → tile 1 replies `DETECT_RESP (0x82)`.
-   RC records tile 1's address.
-5. Repeat steps 3–4 for tiles 2–7.
+   This says only that a tile is there; its reported address is ignored.
+3. RC → all: `SET_ADDRESS (0x06)` carrying `0x01` → only tile 0 acts on it,
+   because only tile 0 has its incoming SENSE asserted. It adopts `0x01` and
+   replies `0x86` **from** `0x01`. RC records slot 0 → `0x01`.
+4. RC → tile 0 (`0x01`): `ACTIVATE_SENSE (0x01)` → tile 0 pulls its outgoing
+   SENSE low, selecting tile 1.
+5. Repeat steps 2–4 for tiles 1–7, assigning `0x02`…`0x08`.
 6. RC → all: `CLEAR_SENSE (0x03)` → all tiles release their SENSE lines.
 
-After this sequence the row controller has a complete `slot 0..7 → tile address`
-map.
+After this sequence the row controller has a complete `slot 0..7 → tile
+address` map, and it is trivially `slot + 1` — the map exists so the rest of
+the firmware need not assume that, not because the assignment is interesting.
+
+A tile that answers `DETECT_SENSE` but never acknowledges `SET_ADDRESS` is a
+**fault**, not the end of the chain: it is demonstrably present. Discovery
+fails rather than silently truncating the row. End of chain is signalled only
+by silence at `DETECT_SENSE` (§7).
 
 ---
 
 ## 10. Open Questions
 
-- **Tile address assignment:** how are unique addresses burned in at
-  manufacture? Options: factory programming via UPDI, derived from ATtiny3224
-  unique serial, or a one-time self-assignment command.
 - **Baud rate confirmation:** 1 Mbps requires validation against the ATtiny3224
   UART tolerance and cable length/capacitance on the tile bus.
 - **Response timeout value:** 5 ms is a placeholder. Tune after measuring

--- a/src/common/tile_bus_protocol/protocol.h
+++ b/src/common/tile_bus_protocol/protocol.h
@@ -4,6 +4,13 @@
 static constexpr uint8_t PROTO_SYNC1    = 0xAA;
 static constexpr uint8_t PROTO_SYNC2    = 0x55;
 static constexpr uint8_t ADDR_BROADCAST = 0xFF;
+// A tile holds this until the row assigns it one during the SENSE walk. It is
+// the "Reserved" address of docs/tile-bus-protocol.md §3, so no frame is ever
+// legitimately sent to it and an unaddressed tile answers only broadcasts -
+// which is all it needs, since DETECT_SENSE and SET_ADDRESS are both
+// broadcast. Addresses are assigned by position and need only be unique on
+// one Tile Bus: the floor's 8 rows are 8 separate buses that never join.
+static constexpr uint8_t ADDR_UNASSIGNED = 0x00;
 // ---- LED geometry ----
 // A build specification, not a preference: the strip is 300 LED/5m and the
 // wooden frame's ledge gives ~10" of the tile's 15" side to lay it on, so
@@ -36,6 +43,7 @@ enum class Cmd : uint8_t {
     CLEAR_SENSE    = 0x03,
     TEST           = 0x04,
     VERSION        = 0x05,
+    SET_ADDRESS    = 0x06,
     SET_COLOR      = 0x10,
     SET_PATTERN    = 0x11,
     SET_LEDS       = 0x12,

--- a/src/row/include/fw_version.h
+++ b/src/row/include/fw_version.h
@@ -5,4 +5,4 @@
 // A PR touching src/common/tile_bus_protocol bumps this AND
 // src/tile/include/fw_version.h's TILE_FW_VERSION. Plain incrementing
 // integer - gaps are fine, going backwards is not.
-static constexpr uint16_t ROW_FW_VERSION = 1;
+static constexpr uint16_t ROW_FW_VERSION = 2;

--- a/src/row/lib/row_core/sense_mapper.cpp
+++ b/src/row/lib/row_core/sense_mapper.cpp
@@ -12,6 +12,19 @@ void SenseMapper::send_detect_sense() {
     transport_.send(f);
 }
 
+void SenseMapper::send_set_address(uint8_t addr) {
+    // Broadcast on purpose: the tile being addressed may not have an address
+    // yet, so there is nothing to unicast to. The SENSE walk is what makes
+    // this unambiguous - exactly one tile has its incoming line asserted, and
+    // only that tile acts on this.
+    Frame f{};
+    f.addr       = ADDR_BROADCAST;
+    f.cmd        = (uint8_t)Cmd::SET_ADDRESS;
+    f.len        = 1;
+    f.payload[0] = addr;
+    transport_.send(f);
+}
+
 void SenseMapper::send_activate_sense(uint8_t addr) {
     Frame f{};
     f.addr = addr;
@@ -140,15 +153,14 @@ void SenseMapper::poll(uint32_t now_ms) {
         Frame f;
         if (transport_.poll(parser_, &f)) {
             if (f.cmd == (uint8_t)Cmd::DETECT_RESP) {
-                map_.set_discovered(current_slot_, f.addr);
-                if (current_slot_ > 0) {
-                    extra_slot_pending_ = true;
-                    extra_slot_        = current_slot_;
-                    extra_slot_addr_   = f.addr;
-                }
-                send_activate_sense(f.addr);
+                // Deliberately ignore the address this frame carries. It
+                // reports whatever the tile currently holds, which for a
+                // freshly booted tile is ADDR_UNASSIGNED and for a tile that
+                // survived a row reset is a stale assignment. DETECT_RESP
+                // means "a tile is here"; what it is called is decided next.
+                send_set_address(address_for_slot(current_slot_));
                 request_sent_ms_ = now_ms;
-                step_ = Step::WAIT_ACTIVATE_ACK;
+                step_ = Step::WAIT_SET_ADDRESS_ACK;
             }
             // else: unrelated frame, ignore and keep waiting.
         } else if (now_ms - request_sent_ms_ >= TIMEOUT_MS) {
@@ -159,6 +171,42 @@ void SenseMapper::poll(uint32_t now_ms) {
                 finish_discovery(now_ms);
             } else {
                 send_detect_sense();
+                request_sent_ms_ = now_ms;
+            }
+        }
+        break;
+    }
+
+    case Step::WAIT_SET_ADDRESS_ACK: {
+        Frame f;
+        const uint8_t assigned = address_for_slot(current_slot_);
+        static constexpr uint8_t SET_ADDRESS_ACK =
+            (uint8_t)Cmd::ACK | (uint8_t)Cmd::SET_ADDRESS;
+        if (transport_.poll(parser_, &f)) {
+            // The tile answers from its new address, so matching on it is
+            // what confirms the assignment landed rather than merely that
+            // something replied.
+            if (f.cmd == SET_ADDRESS_ACK && f.addr == assigned) {
+                map_.set_discovered(current_slot_, assigned);
+                if (current_slot_ > 0) {
+                    extra_slot_pending_ = true;
+                    extra_slot_        = current_slot_;
+                    extra_slot_addr_   = assigned;
+                }
+                send_activate_sense(assigned);
+                request_sent_ms_ = now_ms;
+                step_ = Step::WAIT_ACTIVATE_ACK;
+            }
+            // else: unrelated frame, ignore and keep waiting.
+        } else if (now_ms - request_sent_ms_ >= TIMEOUT_MS) {
+            map_.increment_retry(current_slot_);
+            if (map_.retry_count(current_slot_) > MAX_RETRIES) {
+                // A tile answered DETECT_SENSE and then would not take an
+                // address, so it is present but unusable - a real fault, not
+                // the end of the chain.
+                fail_discovery();
+            } else {
+                send_set_address(assigned);
                 request_sent_ms_ = now_ms;
             }
         }

--- a/src/row/lib/row_core/sense_mapper.h
+++ b/src/row/lib/row_core/sense_mapper.h
@@ -33,9 +33,17 @@ public:
     // from setup1(), the boot retry, and RE_DISCOVER.
     bool take_sweep_started();
 
+    // The address given to the tile found at a slot. Position *is* identity:
+    // tiles boot as ADDR_UNASSIGNED and are numbered as the walk reaches
+    // them, so slot 0 is always 0x01 and the map is 1:1 with the physical
+    // chain. Only has to be unique on this Tile Bus - the floor's 8 rows are
+    // 8 separate buses. See docs/tile-bus-protocol.md §3.
+    static constexpr uint8_t address_for_slot(uint8_t slot) { return (uint8_t)(slot + 1); }
+
 private:
     enum class Step : uint8_t {
-        START, SETTLE, WAIT_DETECT_RESP, WAIT_ACTIVATE_ACK, WAIT_VERSION_RESP
+        START, SETTLE, WAIT_DETECT_RESP, WAIT_SET_ADDRESS_ACK,
+        WAIT_ACTIVATE_ACK, WAIT_VERSION_RESP
     };
 
     // 3 total attempts per docs/tile-bus-protocol.md §7 (1 initial + 2 retries).
@@ -51,6 +59,7 @@ private:
     static constexpr uint32_t SETTLE_MS = 20;
 
     void send_detect_sense();
+    void send_set_address(uint8_t addr);
     void send_activate_sense(uint8_t addr);
     void send_clear_sense(uint8_t addr);
     void broadcast_clear_sense();

--- a/src/row/test/test_sense_mapper/test_sense_mapper.cpp
+++ b/src/row/test/test_sense_mapper/test_sense_mapper.cpp
@@ -9,10 +9,15 @@ void tearDown() {}
 // Fakes
 // ---------------------------------------------------------------------------
 
-// Models a chain of `tile_count` tiles addressed 1..tile_count, one slot at a
-// time becoming "active" (visible to DETECT_SENSE) as each prior tile is
-// successfully ACTIVATE_SENSE'd, mirroring the real SENSE hardware chain
-// closely enough to drive SenseMapper's state machine and timing.
+// Models a chain of `tile_count` tiles, one slot at a time becoming "active"
+// (visible to DETECT_SENSE) as each prior tile is successfully
+// ACTIVATE_SENSE'd, mirroring the real SENSE hardware chain closely enough to
+// drive SenseMapper's state machine and timing.
+//
+// Tiles start at ADDR_UNASSIGNED and only get an address when the walk hands
+// them one, exactly as the firmware does. That matters for more than realism:
+// it is what would catch the mapper regressing to trusting the address in a
+// DETECT_RESP, which under this scheme carries no information.
 class FakeChainTransport : public ITransport {
 public:
     explicit FakeChainTransport(uint8_t tile_count) : tile_count_(tile_count) {}
@@ -33,13 +38,29 @@ public:
                 return;
             }
             pending_frame_ = Frame{};
-            pending_frame_.addr = tile_address(active_slot_);
+            // Whatever this tile currently holds - ADDR_UNASSIGNED until the
+            // row names it. The mapper must not depend on this value.
+            pending_frame_.addr = assigned_[active_slot_];
             pending_frame_.cmd  = (uint8_t)Cmd::DETECT_RESP;
             pending_frame_.len  = 0;
             pending_ = true;
 
+        } else if (cmd == Cmd::SET_ADDRESS) {
+            // Broadcast; only the tile whose SENSE line is asserted acts.
+            if (never_ack_set_address_ || active_slot_ >= tile_count_ || frame.len < 1) {
+                pending_ = false;
+                return;
+            }
+            assigned_[active_slot_] = frame.payload[0];
+            pending_frame_ = Frame{};
+            pending_frame_.addr       = frame.payload[0]; // answers from the new address
+            pending_frame_.cmd        = (uint8_t)Cmd::ACK | (uint8_t)Cmd::SET_ADDRESS;
+            pending_frame_.len        = 1;
+            pending_frame_.payload[0] = 0x00;
+            pending_ = true;
+
         } else if (cmd == Cmd::ACTIVATE_SENSE) {
-            if (never_ack_activate_ || frame.addr != tile_address(active_slot_)) {
+            if (never_ack_activate_ || frame.addr != assigned_[active_slot_]) {
                 pending_ = false;
                 return;
             }
@@ -79,8 +100,18 @@ public:
 
     void fail_first_detect_for_slot(uint8_t slot) { fail_detect_slot_ = slot; }
     void never_ack_activate() { never_ack_activate_ = true; }
+    void never_ack_set_address() { never_ack_set_address_ = true; }
     void never_answer_version_for_addr(uint8_t addr) { fail_version_addr_ = addr; }
 
+    uint8_t assigned_address(uint8_t slot) const { return assigned_[slot]; }
+
+    // Start every tile claiming the same address, as the bench hardware did
+    // before assignment existed (all tiles hardcoded 0x01).
+    void preset_all_addresses(uint8_t addr) {
+        for (uint8_t i = 0; i < TileMap::NUM_SLOTS; i++) assigned_[i] = addr;
+    }
+
+    // The address the row is expected to hand a tile at this slot.
     static uint8_t tile_address(uint8_t slot) { return (uint8_t)(slot + 1); }
 
 private:
@@ -88,10 +119,12 @@ private:
     uint8_t active_slot_ = 0;
     bool    pending_ = false;
     Frame   pending_frame_{};
+    uint8_t assigned_[TileMap::NUM_SLOTS] = {};  // ADDR_UNASSIGNED until named
 
     int     fail_detect_slot_ = -1;
     bool    detect_failed_once_ = false;
     bool    never_ack_activate_ = false;
+    bool    never_ack_set_address_ = false;
     int     fail_version_addr_ = -1;
 };
 
@@ -249,10 +282,76 @@ void test_re_discover_clears_stale_version_cache() {
     TEST_ASSERT_FALSE(map.has_version(0));
 }
 
+// ---------------------------------------------------------------------------
+// Address assignment
+// ---------------------------------------------------------------------------
+
+void test_discovery_assigns_addresses_by_position() {
+    FakeChainTransport transport(8);
+    FakeRowSense sense;
+    TileMap map;
+    SenseMapper mapper(transport, sense, map);
+
+    mapper.start();
+    uint32_t now = 0;
+    run_to_completion(mapper, now);
+
+    TEST_ASSERT_EQUAL(SenseMapState::DONE, mapper.state());
+    for (uint8_t slot = 0; slot < 8; slot++) {
+        // The tile actually took the address...
+        TEST_ASSERT_EQUAL_HEX8(FakeChainTransport::tile_address(slot),
+                               transport.assigned_address(slot));
+        // ...and the row's map agrees, so slot N is always address N+1.
+        TEST_ASSERT_EQUAL_HEX8(FakeChainTransport::tile_address(slot), map.address_for(slot));
+    }
+}
+
+// The whole point of assigning addresses is that a tile's prior address means
+// nothing. Every tile here boots claiming the same stale address, which is
+// precisely the bench condition that made the row unable to tell 8 tiles from
+// one - and it must now discover them correctly regardless.
+void test_identical_reported_addresses_do_not_confuse_discovery() {
+    FakeChainTransport transport(8);
+    transport.preset_all_addresses(0x01);
+    FakeRowSense sense;
+    TileMap map;
+    SenseMapper mapper(transport, sense, map);
+
+    mapper.start();
+    uint32_t now = 0;
+    run_to_completion(mapper, now);
+
+    TEST_ASSERT_EQUAL(SenseMapState::DONE, mapper.state());
+    TEST_ASSERT_EQUAL(8, map.discovered_count());
+    for (uint8_t slot = 0; slot < 8; slot++)
+        TEST_ASSERT_EQUAL_HEX8(FakeChainTransport::tile_address(slot), map.address_for(slot));
+}
+
+// A tile present enough to answer DETECT_SENSE but unable to take an address
+// is a fault, not the end of the chain - the distinction matters because
+// end-of-chain is the normal way discovery finishes.
+void test_set_address_never_acked_reaches_error() {
+    FakeChainTransport transport(4);
+    transport.never_ack_set_address();
+    FakeRowSense sense;
+    TileMap map;
+    SenseMapper mapper(transport, sense, map);
+
+    mapper.start();
+    uint32_t now = 0;
+    run_to_completion(mapper, now);
+
+    TEST_ASSERT_EQUAL(SenseMapState::ERROR, mapper.state());
+    TEST_ASSERT_EQUAL(0, map.discovered_count());
+}
+
 int main(int, char **) {
     UNITY_BEGIN();
 
     RUN_TEST(test_full_discovery_8_tiles);
+    RUN_TEST(test_discovery_assigns_addresses_by_position);
+    RUN_TEST(test_identical_reported_addresses_do_not_confuse_discovery);
+    RUN_TEST(test_set_address_never_acked_reaches_error);
     RUN_TEST(test_short_chain_ends_via_timeout_not_error);
     RUN_TEST(test_activate_sense_never_acked_reaches_error);
     RUN_TEST(test_retry_is_tracked_per_slot);

--- a/src/tile/include/fw_version.h
+++ b/src/tile/include/fw_version.h
@@ -5,4 +5,4 @@
 // A PR touching src/common/tile_bus_protocol bumps this AND
 // src/row/include/fw_version.h's ROW_FW_VERSION. Plain incrementing
 // integer - gaps are fine, going backwards is not.
-static constexpr uint16_t TILE_FW_VERSION = 1;
+static constexpr uint16_t TILE_FW_VERSION = 2;

--- a/src/tile/lib/df2_core/command_handler.cpp
+++ b/src/tile/lib/df2_core/command_handler.cpp
@@ -2,7 +2,7 @@
 #include "fw_version_info.h"
 
 const Frame *handle_command(const Frame &in, PixelBuffer &buf,
-                             ISenseControl &sense, uint8_t my_addr,
+                             ISenseControl &sense, uint8_t &my_addr,
                              PatternEngine *pattern) {
     static Frame response;
 
@@ -62,6 +62,28 @@ const Frame *handle_command(const Frame &in, PixelBuffer &buf,
             return &response;
         }
         return nullptr;
+
+    case Cmd::SET_ADDRESS:
+        // Broadcast, but answered by exactly one tile: the SENSE walk has
+        // asserted precisely one tile's incoming line at this point, so the
+        // row can hand an address to a tile that does not yet have one - the
+        // bootstrap that address-based unicast cannot do for itself. A tile
+        // whose SENSE_IN is not asserted must stay silent, or every tile on
+        // the bus would take the same address at once.
+        if (!sense.sense_is_asserted()) return nullptr;
+        if (in.len < 1) return nullptr;
+        if (in.payload[0] == ADDR_UNASSIGNED || in.payload[0] == ADDR_BROADCAST)
+            return nullptr;  // neither is a usable unicast address (§3)
+
+        my_addr = in.payload[0];
+        // Answering *from* the new address is the acknowledgement that
+        // matters: it proves the assignment took, rather than only that the
+        // command was received.
+        response.addr       = my_addr;
+        response.cmd        = (uint8_t)Cmd::ACK | in.cmd; // 0x86
+        response.len        = 1;
+        response.payload[0] = 0x00; // success
+        return &response;
 
     case Cmd::TEST:
         response.addr       = my_addr;

--- a/src/tile/lib/df2_core/command_handler.h
+++ b/src/tile/lib/df2_core/command_handler.h
@@ -8,8 +8,15 @@
 #include "sense.h"
 
 // Dispatch a received frame to the pixel buffer and/or sense control.
-// my_addr is this tile's unicast address; used when building response frames.
-// Caller must pre-filter: only call when frame.addr == my_addr or ADDR_BROADCAST.
+//
+// my_addr is this tile's unicast address, used when building response frames
+// and taken by reference because SET_ADDRESS changes it: a tile boots as
+// ADDR_UNASSIGNED and is given an address by position during the row's SENSE
+// walk (docs/tile-bus-protocol.md §3). Nothing else writes it.
+//
+// Caller must pre-filter: only call when frame.addr == my_addr or
+// ADDR_BROADCAST. An unaddressed tile therefore sees broadcasts only, which
+// is enough - DETECT_SENSE and SET_ADDRESS are both broadcast.
 // pattern is optional: pass the tile's PatternEngine to enable SET_PATTERN and
 // the pattern-cancelling side effect of SET_COLOR/SET_LEDS. When it is nullptr
 // (harnesses and tests that don't exercise patterns) SET_PATTERN stays the
@@ -17,5 +24,5 @@
 // Returns a pointer to a statically-allocated response frame, or nullptr if no
 // response is needed.
 const Frame *handle_command(const Frame &in, PixelBuffer &buf,
-                             ISenseControl &sense, uint8_t my_addr,
+                             ISenseControl &sense, uint8_t &my_addr,
                              PatternEngine *pattern = nullptr);

--- a/src/tile/src/main.cpp
+++ b/src/tile/src/main.cpp
@@ -7,7 +7,12 @@
 #include "at/led_driver_at.h"
 #include "at/sense_at.h"
 
-static constexpr uint8_t MY_ADDR = 0x01; // TODO: read from EEPROM
+// Assigned by the row during its SENSE walk, not stored anywhere: the walk
+// runs at every boot and derives the address from physical position, so a
+// tile is interchangeable with any other and a replacement needs no
+// programming. Until then it answers broadcasts only, which is enough to
+// receive DETECT_SENSE and SET_ADDRESS. See docs/tile-bus-protocol.md §3.
+static uint8_t my_addr = ADDR_UNASSIGNED;
 
 static TransportAT transport;
 static LedDriverAT led_driver;
@@ -76,8 +81,12 @@ void setup() {
 void loop() {
     Frame f;
     if (transport.poll(parser, &f)) {
-        if (f.addr == MY_ADDR || f.addr == ADDR_BROADCAST) {
-            const Frame *resp = handle_command(f, pixel_buf, sense, MY_ADDR, &pattern);
+        // An unassigned tile must not match on address: ADDR_UNASSIGNED is
+        // reserved and never legitimately targeted, but matching it would
+        // make every unaddressed tile on the bus answer the same frame.
+        const bool for_us = (my_addr != ADDR_UNASSIGNED && f.addr == my_addr);
+        if (for_us || f.addr == ADDR_BROADCAST) {
+            const Frame *resp = handle_command(f, pixel_buf, sense, my_addr, &pattern);
             if (resp) transport.send(*resp);
         }
     }

--- a/src/tile/src/main_native.cpp
+++ b/src/tile/src/main_native.cpp
@@ -28,6 +28,14 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
+    // Given on the command line rather than left ADDR_UNASSIGNED as the real
+    // firmware does: TransportNative takes the address at construction to
+    // register with the broker, so the socket identity is fixed before
+    // SET_ADDRESS could ever arrive. A SET_ADDRESS handled here still updates
+    // my_addr and so changes which frames this process answers, while its
+    // broker routing key does not follow - so socket-broker tests should not
+    // be used to exercise address assignment. The row's own unit tests cover
+    // that path (test_sense_mapper).
     uint8_t my_addr = (uint8_t)strtoul(argv[1], nullptr, 0);
     uint8_t slot    = (uint8_t)strtoul(argv[2], nullptr, 0);
     int     row     = (int)strtol(argv[3], nullptr, 10);

--- a/src/tile/test/test_command_handler/test_command_handler.cpp
+++ b/src/tile/test/test_command_handler/test_command_handler.cpp
@@ -19,11 +19,15 @@ public:
 
 static MockSense mock_sense;
 static PixelBuffer buf;
-static constexpr uint8_t MY_ADDR = 0x05;
+// Mutable because SET_ADDRESS writes it, and restored in setUp() so a test
+// that reassigns the address cannot leak into the next one.
+static constexpr uint8_t DEFAULT_ADDR = 0x05;
+static uint8_t MY_ADDR = DEFAULT_ADDR;
 
 void setUp() {
     buf = PixelBuffer{};
     mock_sense.reset();
+    MY_ADDR = DEFAULT_ADDR;
 }
 void tearDown() {}
 
@@ -231,6 +235,80 @@ void test_version_command_returns_version_resp() {
 }
 
 // ---------------------------------------------------------------------------
+// SET_ADDRESS
+// ---------------------------------------------------------------------------
+
+static Frame set_address_frame(uint8_t addr) {
+    Frame in = {};
+    in.addr       = ADDR_BROADCAST;   // always broadcast: the target may have no address
+    in.cmd        = (uint8_t)Cmd::SET_ADDRESS;
+    in.len        = 1;
+    in.payload[0] = addr;
+    return in;
+}
+
+void test_set_address_assigns_and_acks_from_the_new_address() {
+    mock_sense.asserted = true;       // this tile is the one the walk has selected
+    MY_ADDR = ADDR_UNASSIGNED;
+
+    const Frame *resp = handle_command(set_address_frame(0x03), buf, mock_sense, MY_ADDR);
+
+    TEST_ASSERT_EQUAL_HEX8(0x03, MY_ADDR);
+    TEST_ASSERT_NOT_NULL(resp);
+    // Answering from the new address is what proves the assignment took.
+    TEST_ASSERT_EQUAL_HEX8(0x03, resp->addr);
+    TEST_ASSERT_EQUAL_HEX8(0x86, resp->cmd);
+    TEST_ASSERT_EQUAL_HEX8(1, resp->len);
+    TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[0]);
+}
+
+// The whole scheme rests on this: SET_ADDRESS is a broadcast, so if a tile
+// without its SENSE line asserted acted on it, every tile on the bus would
+// take the same address at once.
+void test_set_address_ignored_when_sense_not_asserted() {
+    mock_sense.asserted = false;
+    MY_ADDR = ADDR_UNASSIGNED;
+
+    TEST_ASSERT_NULL(handle_command(set_address_frame(0x03), buf, mock_sense, MY_ADDR));
+    TEST_ASSERT_EQUAL_HEX8(ADDR_UNASSIGNED, MY_ADDR);
+}
+
+void test_set_address_rejects_reserved_and_broadcast_addresses() {
+    mock_sense.asserted = true;
+
+    TEST_ASSERT_NULL(handle_command(set_address_frame(ADDR_UNASSIGNED), buf, mock_sense, MY_ADDR));
+    TEST_ASSERT_EQUAL_HEX8(DEFAULT_ADDR, MY_ADDR);
+
+    TEST_ASSERT_NULL(handle_command(set_address_frame(ADDR_BROADCAST), buf, mock_sense, MY_ADDR));
+    TEST_ASSERT_EQUAL_HEX8(DEFAULT_ADDR, MY_ADDR);
+}
+
+void test_set_address_ignores_empty_payload() {
+    mock_sense.asserted = true;
+    Frame in = {};
+    in.addr = ADDR_BROADCAST;
+    in.cmd  = (uint8_t)Cmd::SET_ADDRESS;
+    in.len  = 0;
+
+    TEST_ASSERT_NULL(handle_command(in, buf, mock_sense, MY_ADDR));
+    TEST_ASSERT_EQUAL_HEX8(DEFAULT_ADDR, MY_ADDR);
+}
+
+// A row that resets mid-show re-walks the chain while the tiles keep whatever
+// they were given. Reassignment has to be plain overwrite, with no notion of
+// "already addressed", or the second walk would find tiles it cannot rename.
+void test_set_address_overwrites_an_existing_address() {
+    mock_sense.asserted = true;
+    MY_ADDR = 0x07;
+
+    const Frame *resp = handle_command(set_address_frame(0x01), buf, mock_sense, MY_ADDR);
+
+    TEST_ASSERT_EQUAL_HEX8(0x01, MY_ADDR);
+    TEST_ASSERT_NOT_NULL(resp);
+    TEST_ASSERT_EQUAL_HEX8(0x01, resp->addr);
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -259,6 +337,12 @@ int main(int, char **) {
     RUN_TEST(test_test_command_returns_ack);
 
     RUN_TEST(test_version_command_returns_version_resp);
+
+    RUN_TEST(test_set_address_assigns_and_acks_from_the_new_address);
+    RUN_TEST(test_set_address_ignored_when_sense_not_asserted);
+    RUN_TEST(test_set_address_rejects_reserved_and_broadcast_addresses);
+    RUN_TEST(test_set_address_ignores_empty_payload);
+    RUN_TEST(test_set_address_overwrites_an_existing_address);
 
     return UNITY_END();
 }


### PR DESCRIPTION
Tiles all shipped with `MY_ADDR = 0x01` and a `TODO: read from EEPROM`, so a row controller could not tell 8 tiles apart from one tile answering 8 times. Multi-tile addressing did not work at all, and this blocked every multi-tile bring-up test.

[docs/tile-bus-protocol.md](https://github.com/tennessee-garage/dance-more/blob/main/docs/tile-bus-protocol.md) §10 left the assignment scheme open with three candidates: factory programming via UPDI, derivation from the ATtiny's unique serial, or self-assignment. This implements self-assignment.

## Why self-assignment

Two facts collapse the problem, and neither is obvious from the way §3 was written:

**Addresses only need to be unique on one Tile Bus.** §3 called for uniqueness across all 64 tiles, but the floor's 8 rows are 8 electrically separate buses that never join. Eight addresses cover the whole floor.

**The SENSE walk already selects exactly one tile at a time.** That is the one moment a tile with no address can be reached — which is what makes a broadcast assignment unambiguous.

Together they mean position can simply *be* the address. Tiles are physically interchangeable, a replacement works with no programming step, there is no per-tile firmware build to track, and the slot→address map cannot drift out of step with the physical chain.

The rejected alternatives, for the record: factory programming means 64 distinct flash steps plus spares management, and flashing is a physical round trip on this bench. Deriving from the ATtiny serial needs hashing 10 bytes into 1 — 64 tiles into 254 addresses collide with ~99.9% probability, and even 8 per row collide ~11% of the time, so it needs a collision-resolution round on top.

## How it works

A tile boots as `ADDR_UNASSIGNED` (`0x00`) and matches broadcasts only. That is sufficient: `DETECT_SENSE` and `SET_ADDRESS`, the two commands it must see before it has a name, are both broadcast.

During the walk, after each slot's `DETECT_RESP`, the row broadcasts the new `SET_ADDRESS (0x06)` carrying `slot + 1`:

1. RC → all: `DETECT_SENSE` → the selected tile replies `DETECT_RESP`
2. RC → all: `SET_ADDRESS` carrying `0x01` → only the selected tile acts, adopts `0x01`, replies `0x86` **from** `0x01`
3. RC → `0x01`: `ACTIVATE_SENSE` → selects the next tile
4. Repeat, assigning `0x02`…`0x08`

Three details are load-bearing:

- **A tile whose SENSE line is not asserted must ignore `SET_ADDRESS` entirely.** It is a broadcast; without this rule every tile on the bus takes the same address at once. This has its own test.
- **The ACK is sent from the new address.** An ACK from the old one would only prove the command arrived; from the new one it proves the assignment took. The row matches on it before recording the slot.
- **Assignment is a plain overwrite**, with no notion of "already addressed" — a row that resets mid-show re-walks a chain of tiles still holding their previous names and has to be able to rename them.

`DETECT_RESP`'s address field is now deliberately ignored. It reports whatever the tile currently holds: `ADDR_UNASSIGNED` on a fresh boot, a stale assignment after a row reset. Trusting it is what let one tile answering repeatedly look like eight distinct ones. The doc previously described that field as "what the row controller captures", which is now exactly what a reader must not do.

A tile that answers `DETECT_SENSE` but then will not take an address is treated as a **fault**, not end-of-chain — it is demonstrably present, so truncating the row silently would be wrong. End of chain stays signalled only by silence at `DETECT_SENSE`.

## What this does *not* fix

It does not fix the intermittent phantom-8 discovery. A tile that answers at slot 1 simply gets renamed to `0x02`, and the row still reports 8 tiles.

It does make one **self-evident**, which the old scheme could not. Because each tile abandons its old address on reassignment, a cascade leaves slots 0–6 pointing at addresses nothing answers to — so the post-discovery VERSION sweep comes back with `has_version()` false for every slot but the last. That is a free automatic signature worth checking before instrumenting anything further.

## Testing

- 58 row unit tests, 60 tile unit tests, all passing
- `pio run -e row0` and `pio run -e ATtiny3226` both build
- Tile cost: 60 bytes of flash (19.3% → 19.5% on an ATtiny3226)

New coverage worth calling out: the row's test fake now models tiles that **start unassigned and adopt what they are given**, rather than tiles that already know their names. That is what lets it cover the case that actually matters — eight tiles all claiming `0x01`, exactly the bench hardware before this change — and discover them correctly.

**Not yet tested on hardware.** Both the row and the tile need reflashing, which is two socket pulls on this bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
