### PR TITLE
Verify tiles are rendering by their current draw

### DIFF
--- a/docs/power.md
+++ b/docs/power.md
@@ -7,15 +7,18 @@ The floor runs on **12 V**, supplied by two line-powered **Mean Well 12 V /
 
 | Scope | LEDs | Current @ 12 V (full white) | Power |
 | --- | --- | --- | --- |
-| Per tile | 60 | **~0.75 A** | ~9 W |
-| Per row (8 tiles) | 480 | ~6 A | ~72 W |
-| Whole floor (64 tiles) | 3,840 | **~48 A** | **~576 W** |
+| Per tile | 60 | **~0.55 A** | ~6.6 W |
+| Per row (8 tiles) | 480 | ~4.4 A | ~53 W |
+| Whole floor (64 tiles) | 3,840 | **~35 A** | **~420 W** |
 
-- These are the **40-LED measurements scaled by 1.5** for the move to 60
-  LEDs/tile. Per-LED draw doesn't change with strip density — 300 LED/5m and
-  150 LED/5m use the same WS2815 emitters at a different pitch — so the scaling
-  is straightforward, but the figures below are **derived, not measured at 60**.
-  Re-run `tile_brightness_sweep.py` on a 60-LED tile to confirm.
+- **Measured at 60 LEDs** on 2026-09-08, via a row controller's own INA226
+  with two tiles attached. These replace the earlier figures, which were the
+  40-LED measurements scaled by 1.5 and put per-tile draw at ~0.75 A.
+- The scaled numbers were high because they assumed white costs the sum of
+  three channels. It does not — see "LED current tracks the brightest
+  channel" below, which is why the floor total drops from ~48 A to ~35 A.
+- LED current only: it excludes the ATtiny3224, the Xiao row controllers and
+  the transceivers. A row controller plus two idle tiles measured 0.30 A.
 - The underlying **0.5 A/tile at 40 LEDs** is a measured worst case (40 WS2815
   LEDs at full white). It is **LED current only** — it does not include the
   ATtiny3224, the Xiao row controllers, or transceivers.
@@ -48,14 +51,40 @@ The floor runs on **12 V**, supplied by two line-powered **Mean Well 12 V /
 
 ### Load vs. capacity
 
-| | Per row (LED) | Per supply (4 rows, LED) | Per supply rating |
-| --- | --- | --- | --- |
-| Current @ 12 V | ~6 A | ~24 A | **40 A** |
+Measured on the bench (2026-09-08, one row controller and two tiles, via the
+row's own INA226), rather than scaled from the 40-LED numbers:
 
-Each 40 A supply carries roughly **24 A of LED load** at full white (plus
-controller/logic draw). That still fits, but the move from 40 to 60 LEDs/tile
-took the margin from 2.5× down to **1.67×** — the supplies remain adequate,
-and are no longer generously so.
+| | Per tile (LED) | Per row (8 tiles) | Per supply (4 rows) | Per supply rating |
+| --- | --- | --- | --- | --- |
+| Full white @ 12 V | **0.55 A** | ~4.4 A | ~17.6 A | **40 A** |
+
+That is a **2.3× margin**, not the 1.67× this section previously estimated by
+scaling. Logic draw is on top: a row controller plus two idle tiles measured
+0.30 A, so allow roughly 0.15 A per row of controller/transceiver/ATtiny
+overhead.
+
+### LED current tracks the brightest channel, not the sum
+
+The measurement that moves the number. Tile current follows the sum over LEDs
+of **max(R, G, B)** — not R+G+B:
+
+| Commanded (all 60 LEDs) | Channel sum | Measured |
+| --- | --- | --- |
+| `(200, 0, 0)` | 200 | 427 mA |
+| `(200, 200, 0)` | 400 | 427 mA |
+| `(200, 200, 200)` | 600 | 429 mA |
+| `(255, 255, 255)` | 765 | 549 mA |
+| `(255, 0, 0)` | 255 | 548 mA |
+
+So **full white costs the same as a single primary at the same level**, and a
+three-channel estimate overstates white by ~3×. On the governing channel the
+relationship is linear to better than 1%, and predictions from it matched
+measurement within 2 mA of 427 across solid, gradient and rainbow frames.
+Per-tile draw is additive to within 1 mA.
+
+The mechanism is **not confirmed** — the WS2815 datasheet has not been checked
+against this — so treat the relationship as an empirical result that holds
+across the range tested, not as a datasheet claim.
 
 ## Why 12 V
 
@@ -72,13 +101,17 @@ and are no longer generously so.
 
 ## Open Questions
 
-- **Confirm the 60-LED figures by measurement** rather than by scaling — see
-  the note above. Everything in this doc is currently 1.5× the 40-LED numbers.
-- **Controller/logic current:** add the ATtiny3224, Xiao, and transceiver draw
-  on top of the ~24 A/supply LED figure (still under 40 A).
+- **Confirm the mechanism behind the max-channel result** against the WS2815
+  datasheet. The measurement is solid and repeatable; the explanation is not
+  established, and the whole supply margin now rests on it holding at scale.
+- **Re-measure with more than two tiles.** Per-tile draw was additive to
+  within 1 mA at two, but the full-row figure is still 8× a two-tile
+  measurement rather than a measured row.
 - **Voltage drop** along the 16 AWG per-tile splice run — confirm 12 V holds at
-  the last tile in a row. **This got 50% worse at 60 LEDs** (~6 A per row
-  rather than ~4 A) and is now the most pressing open question here, because
+  the last tile in a row. At the measured 60-LED figure this is ~4.4 A per row
+  rather than the ~6 A previously assumed — better than feared, but still up
+  from ~4 A at 40 LEDs, and it remains the most pressing open question here
+  because
   the fix is a wiring-layout decision worth making once. The lever is **where
   the 14 AWG feeder enters the row** (i.e. row-controller placement), not the
   16 AWG. Extending 16 AWG to the middle does **not** help: that feeder segment

--- a/src/pi/test/integration/live_demo.py
+++ b/src/pi/test/integration/live_demo.py
@@ -122,6 +122,42 @@ SAG_THRESHOLD_MV = 300
 LOAD_SETTLE_S = 0.25
 
 
+# ---- Power-based tile verification ----
+#
+# Display commands carry no ACK by design (docs/tile-bus-protocol.md), so a
+# tile that has stopped rendering is invisible to every other channel here:
+# STATUS reports the row's cached tile map, which is frozen at discovery, and
+# the row never re-checks a tile afterwards. Measured supply current is the
+# only signal that comes from the tiles themselves rather than from the row
+# talking about them.
+#
+# Measured on the bench 2026-09-08, one row + two tiles: LED current tracks
+# the sum over LEDs of max(r,g,b) - NOT the sum of the channels. (200,200,200)
+# draws the same as (200,0,0); (255,255,255) the same as (255,0,0). On that
+# governing channel it is linear to better than 1%: predictions matched
+# measurement within 2 mA of 427 across solid, gradient and rainbow frames.
+# Mechanism unconfirmed - the WS2815 datasheet has not been checked - but the
+# relationship is solid enough to predict from.
+#
+# Consequence worth knowing: a full-saturation rotating rainbow has max=level
+# on every LED, so its predicted draw is constant and a frozen tile looks
+# identical to a live one. The SET_COLOR phase is what makes a freeze visible,
+# because its commanded draw actually moves.
+POWER_VERIFY_TOLERANCE_MA = 60   # ~14% of one tile at level 200; noise is ~2 mA
+POWER_CAL_LEVEL = 150            # calibration brightness, well clear of any limit
+POWER_VERIFY_CONFIRM_S = 0.30    # re-read gap before believing a mismatch
+
+
+def per_tile_max_sum(pixels: list[tuple[int, int, int]]) -> int:
+    """Sum of max(r,g,b) over one tile's LEDs - the quantity current tracks."""
+    return sum(max(px) for px in pixels)
+
+
+# Filled by calibrate_power(); None until then, which disables the check.
+POWER_CAL: dict[str, float | None] = {"dark_ma": None, "ma_per_unit": None}
+LAST_FRAME_PER_TILE_MAX = 0
+
+
 def set_color_payload(fractions: tuple[float, float, float], level: int) -> bytes:
     r, g, b = (int(f * level) for f in fractions)
     return bytes([TileCmd.SET_COLOR, r, g, b]) * 8
@@ -145,7 +181,8 @@ def probe(floor: Floor, row: int, cmd: int) -> bytes | None:
         return None
 
 
-def show_frame(floor: Floor, rows: list[int], payload: bytes, latch_delay_s: float) -> None:
+def show_frame(floor: Floor, rows: list[int], payload: bytes, latch_delay_s: float,
+               per_tile_max: int = 0) -> None:
     """SEND_DATA to every row, then LATCH once.
 
     The gap before LATCH lets each row finish forwarding to its tiles first.
@@ -169,6 +206,11 @@ def show_frame(floor: Floor, rows: list[int], payload: bytes, latch_delay_s: flo
     if latch_delay_s:
         time.sleep(latch_delay_s)
     floor.latch()
+    # Remember what is on the tiles so verify_power() can predict the draw it
+    # should be causing. Set after the LATCH, so a frame that was sent but
+    # never latched is not what we check against.
+    global LAST_FRAME_PER_TILE_MAX
+    LAST_FRAME_PER_TILE_MAX = per_tile_max
 
 
 def read_power(floor: Floor, row: int) -> tuple[int, int, int] | None:
@@ -278,6 +320,129 @@ def print_error_log(row: int, payload: bytes, last_log: dict[int, list[tuple]]) 
             print(f"      {mark}slot={slot} tile_cmd=0x{tile_cmd:02X} type={name} t={t}s")
 
 
+def calibrate_power(floor: Floor, rows: list[int], tiles: int, latch_delay_s: float) -> bool:
+    """Learn this rig's dark draw and mA per unit of commanded max-channel.
+
+    Measured rather than hardcoded because the coefficient is a property of
+    the strips actually attached - LED count, and whatever the WS2815 is
+    really doing across channels. Two points are enough: the relationship is
+    linear through the origin to better than 1%.
+    """
+    if not tiles:
+        return False
+    dark = [(0, 0, 0)] * NUM_LEDS
+    lit = [(POWER_CAL_LEVEL, 0, 0)] * NUM_LEDS
+
+    show_frame(floor, rows, set_leds_payload(dark), latch_delay_s, per_tile_max_sum(dark))
+    time.sleep(LOAD_SETTLE_S)
+    dark_reading = read_power(floor, rows[0])
+
+    show_frame(floor, rows, set_leds_payload(lit), latch_delay_s, per_tile_max_sum(lit))
+    time.sleep(LOAD_SETTLE_S)
+    lit_reading = read_power(floor, rows[0])
+
+    show_frame(floor, rows, set_leds_payload(dark), latch_delay_s, per_tile_max_sum(dark))
+    time.sleep(LOAD_SETTLE_S)   # don't hand the caller a rail still settling
+
+    if dark_reading is None or lit_reading is None:
+        print("    power check: calibration failed - POWER did not answer")
+        return False
+
+    units = per_tile_max_sum(lit) * tiles
+    delta = lit_reading[1] - dark_reading[1]
+    if delta <= 0 or not units:
+        print(f"    power check: calibration failed - lighting {tiles} tile(s) "
+              f"changed current by {delta} mA; nothing is rendering")
+        return False
+
+    POWER_CAL["dark_ma"] = dark_reading[1]
+    POWER_CAL["ma_per_unit"] = delta / units
+    per_tile_full = POWER_CAL["ma_per_unit"] * NUM_LEDS * 255
+    print(f"    power check: calibrated - dark {dark_reading[1]} mA, "
+          f"{delta} mA for {tiles} tile(s) at level {POWER_CAL_LEVEL} "
+          f"(~{per_tile_full:.0f} mA per tile at full brightness)")
+    return True
+
+
+def predicted_ma(tiles: int) -> float | None:
+    """What the rail should be drawing for the frame currently latched."""
+    if POWER_CAL["ma_per_unit"] is None:
+        return None
+    return POWER_CAL["dark_ma"] + POWER_CAL["ma_per_unit"] * LAST_FRAME_PER_TILE_MAX * tiles
+
+
+def verify_power(floor: Floor, row: int, tiles: int) -> bool:
+    """Compare measured draw against the frame we commanded.
+
+    True if it matches (or the check is not calibrated). A mismatch is the
+    only evidence available that a tile stopped rendering - see the note on
+    POWER_VERIFY_TOLERANCE_MA.
+    """
+    expected = predicted_ma(tiles)
+    if expected is None:
+        return True
+    reading = read_power(floor, row)
+    if reading is None:
+        return True  # a silent row is health_poll's business, not ours
+    measured = reading[1]
+    err = measured - expected
+    if abs(err) <= POWER_VERIFY_TOLERANCE_MA:
+        return True
+
+    # Confirm before believing it. The first bench run of this check reported
+    # both tiles dark on the very first colour, reading exactly the previous
+    # frame's draw, and both were fine a second later - a stale sample, not a
+    # fault. Frame delivery itself was then measured at 0 losses in 125
+    # trials across inter-frame gaps from 0 to 33 ms, so a single disagreeing
+    # sample is far likelier to be the reading than the tiles. Isolating
+    # tiles blanks the floor, so it must not run on one sample.
+    time.sleep(POWER_VERIFY_CONFIRM_S)
+    reading = read_power(floor, row)
+    if reading is None:
+        return True
+    measured = reading[1]
+    err = measured - expected
+    if abs(err) <= POWER_VERIFY_TOLERANCE_MA:
+        return True
+    share = POWER_CAL["ma_per_unit"] * LAST_FRAME_PER_TILE_MAX or 1
+    print(f"    row 0x{row:02X}: POWER MISMATCH - expected ~{expected:.0f} mA for the "
+          f"commanded frame, measured {measured} mA ({err:+.0f}, "
+          f"~{abs(err) / share:.1f} tile-equivalents)")
+    return False
+
+
+def identify_dark_tiles(floor: Floor, row: int, tiles: int, latch_delay_s: float) -> None:
+    """Light each tile alone and name the ones that don't draw their share.
+
+    Only worth the disruption once verify_power() has already failed. Per-tile
+    draw was measured additive to within 1 mA on the bench, so attribution is
+    unambiguous.
+    """
+    if POWER_CAL["ma_per_unit"] is None:
+        return
+    dark = [(0, 0, 0)] * NUM_LEDS
+    lit = [(POWER_CAL_LEVEL, 0, 0)] * NUM_LEDS
+    expect = POWER_CAL["ma_per_unit"] * per_tile_max_sum(lit)
+    print(f"    isolating tiles (expect ~{expect:.0f} mA each)...")
+
+    for slot in range(tiles):
+        body = b"".join(
+            bytes([TileCmd.SET_LEDS]) + b"".join(bytes(p) for p in (lit if i == slot else dark))
+            for i in range(8)
+        )
+        show_frame(floor, [row], body, latch_delay_s, 0)
+        time.sleep(LOAD_SETTLE_S + POWER_VERIFY_CONFIRM_S)
+        reading = read_power(floor, row)
+        if reading is None:
+            print(f"      slot {slot}: POWER did not answer")
+            continue
+        delta = reading[1] - POWER_CAL["dark_ma"]
+        verdict = "ok" if delta > expect * 0.5 else "NOT RENDERING"
+        print(f"      slot {slot}: {delta:+.0f} mA  {verdict}")
+
+    show_frame(floor, [row], set_leds_payload(dark), latch_delay_s, 0)
+
+
 def health_poll(floor: Floor, row: int, last_log: dict[int, list[tuple]]) -> bool:
     """STATUS, POWER and ERROR_LOG for one row. False if the row is silent.
 
@@ -374,6 +539,19 @@ def drive(floor: Floor, rows: list[int], stats_interval: float, latch_delay_s: f
             baseline_mV[row] = reading[0]
 
     print(f"\nDriving {len(active)} row(s): {', '.join(f'0x{r:02X}' for r in active)}")
+
+    # Total tiles across every driven row: the predicted draw scales with it,
+    # and it comes from STATUS rather than the payload because a payload
+    # always carries all 8 slots while only discovered ones are forwarded.
+    tiles = 0
+    for row in active:
+        st = probe(floor, row, Cmd.STATUS)
+        if st:
+            tiles += st[1]
+    if tiles:
+        calibrate_power(floor, active, tiles, latch_delay_s)
+    else:
+        print("    power check: no tiles discovered - nothing to verify")
     print("Ctrl+C to stop.\n")
 
     next_stats = time.perf_counter() + stats_interval
@@ -434,9 +612,18 @@ def drive(floor: Floor, rows: list[int], stats_interval: float, latch_delay_s: f
         print("-- SET_COLOR phase --")
         for name, fractions in COLOR_CYCLE:
             print(f"   {name}", flush=True)
-            show_frame(floor, active, set_color_payload(fractions, level), latch_delay_s)
+            colour = tuple(int(f * level) for f in fractions)
+            show_frame(floor, active, set_color_payload(fractions, level), latch_delay_s,
+                       max(colour) * NUM_LEDS)
             time.sleep(LOAD_SETTLE_S)
             sample_under_load(floor, active, name, baseline_mV)
+            # Checked here, not in the rainbow: a full-saturation rainbow has
+            # max = level on every LED, so its predicted draw never moves and
+            # a frozen tile is indistinguishable from a live one. The colour
+            # steps are what make a freeze visible.
+            for row in list(active):
+                if not verify_power(floor, row, tiles):
+                    identify_dark_tiles(floor, row, tiles, latch_delay_s)
             time.sleep(max(0.0, COLOR_HOLD_S - LOAD_SETTLE_S))
             maybe_rediscover()
             maybe_stats()
@@ -452,8 +639,9 @@ def drive(floor: Floor, rows: list[int], stats_interval: float, latch_delay_s: f
         phase = 0.0
         while time.perf_counter() < phase_end and active:
             due = time.perf_counter() + period
-            payload = set_leds_payload([wheel(i / NUM_LEDS + phase, level) for i in range(NUM_LEDS)])
-            show_frame(floor, active, payload, latch_delay_s)
+            pixels = [wheel(i / NUM_LEDS + phase, level) for i in range(NUM_LEDS)]
+            show_frame(floor, active, set_leds_payload(pixels), latch_delay_s,
+                       per_tile_max_sum(pixels))
             phase += 0.015
             maybe_stats()
             remaining = due - time.perf_counter()


### PR DESCRIPTION
A tile that stops rendering is currently invisible. Display commands carry no ACK by design ([docs/tile-bus-protocol.md](https://github.com/tennessee-garage/dance-more/blob/main/docs/tile-bus-protocol.md)), `STATUS` reports a tile map frozen at discovery, and the row never re-checks a tile afterwards. On the bench a row kept forwarding to two frozen tiles for 45 minutes and reported a healthy floor throughout.

Supply current is the only signal that comes from the tiles themselves rather than from the row talking about them, and the row's INA226 already measures the whole row. This makes it a check.

## What it does

`live_demo` calibrates against whatever is attached at startup — one dark reading plus one lit frame — then predicts the draw each commanded frame should cause and compares. On a mismatch it lights each tile alone and names the ones not drawing their share.

Calibrated rather than hardcoded because the coefficient belongs to the strips actually attached.

## The measurement that shaped it

Tile current tracks the sum over LEDs of **max(R, G, B)** — not the sum of the channels:

| Commanded (all 60 LEDs) | Channel sum | Measured |
| --- | --- | --- |
| `(200, 0, 0)` | 200 | 427 mA |
| `(200, 200, 0)` | 400 | 427 mA |
| `(200, 200, 200)` | 600 | 429 mA |
| `(255, 255, 255)` | 765 | 549 mA |
| `(255, 0, 0)` | 255 | 548 mA |

Full white costs the same as a single primary at the same level. On the governing channel it is linear to better than 1%, and predictions matched measurement within **2 mA of 427** across solid, gradient and rainbow frames. Per-tile draw is additive to within 1 mA, which is what makes per-tile attribution unambiguous.

This also explains a result from Saturday that went unexplained at the time: WHITE at 0.75 brightness drew *less* than RED at 1.0, because 150 beats 200 on nothing.

## Two things that are easy to get wrong, so they are in the comments

**A rotating rainbow cannot reveal a frozen tile.** Full saturation means `max = level` on every LED, so the predicted draw never moves and a frozen tile draws exactly what a live one does. The check runs during the `SET_COLOR` phase, whose commanded draw actually changes. This is precisely why the 45-minute freeze went unnoticed.

**A mismatch is confirmed with a second reading before isolating**, because the isolation sweep blanks the floor. The first bench run reported both tiles dark on the very first colour, reading exactly the previous frame's draw, with both fine a second later — a stale sample, not a fault. Frame delivery was then measured separately at **0 losses in 125 trials** across inter-frame gaps from 0 to 33 ms, so a single disagreeing sample is far likelier to be the reading than the tiles.

## docs/power.md: a correction, not a refresh

The previous figures scaled 40-LED measurements by 1.5 *and* assumed white costs three channels. Measured at 60 LEDs:

| | Was (scaled) | Measured |
| --- | --- | --- |
| Per tile, full white | ~0.75 A | **~0.55 A** |
| Whole floor (64 tiles) | ~48 A | **~35 A** |
| Supply margin | 1.67× | **2.3×** |

That closes the doc's standing *"confirm the 60-LED figures by measurement"* open question, and replaces it with a narrower and more honest one: the mechanism behind the max-channel result is **unconfirmed against the WS2815 datasheet**, and the whole supply margin now rests on it holding at scale. A second open question notes the per-row figure is still 8× a two-tile measurement rather than a measured row.

## Testing

Validated on the bench, one row and two tiles:

- **Control** — both tiles lit, no false positive, across three runs
- **Fault** — a deliberately short frame detected at −429 mA, exactly 1.0 tile-equivalents
- **Isolation** — per-tile draw resolved at +319 mA and +321 mA
- 72 host tests pass on the Pi

Host-side only; no firmware change, so no version bump and nothing to reflash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
