### PR TITLE
Row diagnostics: report uptime, protect the boot entry, retire a false-positive

### DIFF
--- a/docs/row-bus-protocol.md
+++ b/docs/row-bus-protocol.md
@@ -208,13 +208,25 @@ tile slot in its row.
 | Payload | none |
 | ACK     | **Yes** (`0x82 STATUS_RESP`); allow up to 20 ms |
 
-Response payload (10 bytes):
+Response payload (14 bytes):
 
 | Byte  | Field           | Description |
 | ----- | --------------- | ----------- |
 | 0     | `state`         | `0x00` = idle, `0x01` = discovering, `0x02` = running, `0x03` = error |
 | 1     | `tiles_found`   | Number of tiles successfully discovered (0–8) |
 | 2–9   | `tile_status[0..7]` | Per-slot status: `0x00` = not discovered, `0x01` = OK, `0x02` = non-responsive, `0x03` = test failed |
+| 10–13 | `uptime_s`      | Seconds since the row controller booted (uint32, big-endian) |
+
+`uptime_s` decreasing between two polls is a reboot, and is the only direct
+way to detect one. The alternative — watching the newest `ERROR_LOG`
+timestamp — only advances while the row is logging, which on a healthy row is
+almost never, so a stale clock is indistinguishable from a steady one. It is
+32 bits because a uint16 of seconds wraps at 18.2 hours, and a floor is
+expected to run longer than that; a wrap would read as exactly the reboot the
+field exists to rule out.
+
+Hosts should treat a payload shorter than 14 bytes as firmware predating this
+field rather than as a malformed reply.
 
 ---
 
@@ -287,7 +299,7 @@ Response payload:
 | 0         | `entry_count` | Number of log entries that follow (0–32) |
 | 1 + 5×i   | `slot`        | Tile slot (0–7) that failed; see note for `LATCH_OVERRUN` |
 | 2 + 5×i   | `tile_bus_cmd`   | Tile Bus command code involved; see note for `LATCH_OVERRUN` |
-| 3 + 5×i   | `error_type`  | `0x01` = no ACK after 3 retries, `0x02` = CRC failure, `0x03` = sense collision, `0x04` = LATCH overrun, `0x05` = Row Bus RX overflow, `0x06` = row boot, `0x07` = sense extra slot, `0x08` = sense start |
+| 3 + 5×i   | `error_type`  | `0x01` = no ACK after 3 retries, `0x02` = CRC failure, `0x03` = sense collision, `0x04` = LATCH overrun, `0x05` = Row Bus RX overflow, `0x06` = row boot, `0x08` = sense start, `0x09` = tile no version. `0x07` is **retired** — see below |
 | 4–5 + 5×i | `timestamp`   | Seconds since row controller boot (uint16, big-endian) |
 
 `ROW_BUS_RX_OVERFLOW` (`error_type = 0x05`) reports a receive overrun on the
@@ -320,13 +332,28 @@ the fields:
   these also answer whether a restart *was* a reset: sweeps logged either side
   of a gap mean the chip kept running, whereas a log that starts over means it
   rebooted.
-- `SENSE_EXTRA_SLOT` (`0x07`) — discovery assigned a tile to slot 1 or higher.
-  `slot` is the slot claimed, `tile_bus_cmd` is the address it was given. On a
-  single-tile row this should never appear; it exists to catch the row
-  intermittently coming up claiming all 8 slots at one address, which no
-  captured sense walk has ever produced on the wire.
+- `TILE_NO_VERSION` (`0x09`) — discovery mapped a tile that then would not
+  answer `VERSION`. `slot` is the slot, `tile_bus_cmd` the address it was
+  assigned. The post-discovery version sweep already detected this and moved
+  on silently; now it says so. It catches a tile that took an address and then
+  died, one unplugged mid-run, and — because `SET_ADDRESS` makes a tile
+  abandon its previous address — a row that mis-walked one tile into several
+  slots, which shows up here as *every slot but the last* going silent.
 
-Maximum response payload: `1 + 32 × 5 = 161 bytes`.
+`0x07` (`SENSE_EXTRA_SLOT`) is **retired**. It flagged "discovery assigned a
+tile to slot 1 or higher", which was a usable proxy for the mis-walk only
+while a bench had a single tile. Once addresses are assigned by position, slot
+1 holding `0x02` is simply correct, so it fired on every sweep of a healthy
+two-tile row — twice a second through the boot retry window, filling the ring
+in 16 seconds and evicting `ROW_BOOT`. The code is not reused, so an older
+row's entries decode as unknown rather than being mislabelled.
+
+`ROW_BOOT` is stored outside the ring buffer and always reported first, so a
+busy row cannot evict the entry that says why it last restarted. The ring
+holds the other 31 entries, keeping the response at the same maximum.
+
+Maximum response payload: `1 + 32 × 5 = 161 bytes` — 31 ring entries plus
+`ROW_BOOT`, unchanged from before it was moved out of the ring.
 
 ---
 

--- a/src/pi/src/df2_pi/cli.py
+++ b/src/pi/src/df2_pi/cli.py
@@ -42,8 +42,17 @@ def _cmd_status(args: argparse.Namespace) -> int:
             print(exc, file=sys.stderr)
             return 1
         state, tiles = frame.payload[0], frame.payload[1]
+        # Uptime is appended after the 8 tile-status bytes; a shorter payload
+        # is firmware that predates the field, not a malformed reply.
+        up = ""
+        if len(frame.payload) >= 14:
+            p = frame.payload
+            secs = (p[10] << 24) | (p[11] << 16) | (p[12] << 8) | p[13]
+            h, rem = divmod(secs, 3600)
+            m, sec = divmod(rem, 60)
+            up = f" up={h}h{m:02d}m{sec:02d}s"
         print(f"row 0x{frame.addr:02X} (chain {floor.chain_map.chain_for(args.row)}): "
-              f"state={STATUS_STATE_NAMES.get(state, hex(state))} tiles_found={tiles}")
+              f"state={STATUS_STATE_NAMES.get(state, hex(state))} tiles_found={tiles}{up}")
         return 0
 
 

--- a/src/pi/test/integration/live_demo.py
+++ b/src/pi/test/integration/live_demo.py
@@ -63,7 +63,7 @@ STATUS_STATE_NAMES = {0x00: "idle", 0x01: "discovering", 0x02: "running", 0x03: 
 TILE_STATUS_NAMES = {0x00: "not_discovered", 0x01: "ok", 0x02: "non_responsive", 0x03: "test_failed"}
 ERROR_TYPE_NAMES = {0x01: "no_ack_after_retries", 0x02: "crc_failure", 0x03: "sense_collision",
                     0x04: "latch_overrun", 0x05: "row_bus_rx_overflow",
-                    0x06: "row_boot", 0x07: "sense_extra_slot", 0x08: "sense_start"}
+                    0x06: "row_boot", 0x08: "sense_start", 0x09: "tile_no_version"}
 
 # Diagnostic entries whose slot/tile_cmd fields mean something other than the
 # usual "tile slot / Tile Bus command", so the generic line would misread them.
@@ -85,6 +85,23 @@ RESET_CAUSES = [
     (0x0800, "hazard sys reset"),
     (0x1000, "watchdog(rsm)"),
 ]
+
+
+def status_uptime_s(status: bytes) -> int | None:
+    """Row uptime in seconds from a STATUS_RESP, or None on older firmware.
+
+    Appended after the 8 tile-status bytes, so a payload shorter than 14 is a
+    row that predates the field rather than a malformed reply.
+    """
+    if len(status) < 14:
+        return None
+    return (status[10] << 24) | (status[11] << 16) | (status[12] << 8) | status[13]
+
+
+def fmt_uptime(seconds: int) -> str:
+    h, rem = divmod(seconds, 3600)
+    m, sec = divmod(rem, 60)
+    return f"{h}h{m:02d}m{sec:02d}s" if h else (f"{m}m{sec:02d}s" if m else f"{sec}s")
 
 
 def reset_causes(bits: int) -> str:
@@ -152,6 +169,9 @@ def per_tile_max_sum(pixels: list[tuple[int, int, int]]) -> int:
     """Sum of max(r,g,b) over one tile's LEDs - the quantity current tracks."""
     return sum(max(px) for px in pixels)
 
+
+# Row uptime at the previous health poll, for reboot detection.
+LAST_UPTIME: dict[int, int] = {}
 
 # Filled by calibrate_power(); None until then, which disables the check.
 POWER_CAL: dict[str, float | None] = {"dark_ma": None, "ma_per_unit": None}
@@ -276,8 +296,11 @@ def print_error_log(row: int, payload: bytes, last_log: dict[int, list[tuple]]) 
     previous = last_log.get(row)
     prev_newest = max((e[3] << 8) | e[4] for e in previous) if previous else None
     if newest is not None and prev_newest is not None and newest < prev_newest:
-        print(f"    row 0x{row:02X} REBOOTED since the last poll "
-              f"(error-log clock went {prev_newest}s -> {newest}s)")
+        # Fallback for firmware without STATUS uptime; health_poll reports the
+        # reboot directly when the field is present.
+        if row not in LAST_UPTIME:
+            print(f"    row 0x{row:02X} REBOOTED since the last poll "
+                  f"(error-log clock went {prev_newest}s -> {newest}s)")
         previous = None  # the ring restarted; nothing carries across
 
     n_new = count_new_entries(previous, entries)
@@ -292,11 +315,11 @@ def print_error_log(row: int, payload: bytes, last_log: dict[int, list[tuple]]) 
         kinds[e[2]] = kinds.get(e[2], 0) + 1
     summary = ", ".join(f"{ERROR_TYPE_NAMES.get(k, hex(k))}={v}" for k, v in sorted(kinds.items()))
 
-    # The row clock is the only uptime the Pi can see - STATUS_RESP carries
-    # state, tiles_found and the 8 tile statuses, but no uptime field. So it
-    # is a lower bound, and it stops advancing the moment the row stops
-    # logging. That is exactly when it misleads, hence the explicit new-entry
-    # count beside it rather than leaving the reader to date the timestamps.
+    # This clock is a lower bound that stops advancing the moment the row stops
+    # logging, so it is kept only to date entries against each other. Real
+    # uptime now comes from STATUS_RESP and is printed by health_poll; the
+    # explicit new-entry count is what stops a full ring of stale entries
+    # reading as a fresh failure.
     if n_new is None:
         freshness = "all predate this run"
     elif n_new == 0:
@@ -314,8 +337,9 @@ def print_error_log(row: int, payload: bytes, last_log: dict[int, list[tuple]]) 
             print(f"      {mark}{name}: {reset_causes((slot << 8) | tile_cmd)} t={t}s")
         elif err_type == 0x08:
             print(f"      {mark}{name}: sweep #{slot} t={t}s")
-        elif err_type == 0x07:
-            print(f"      {mark}{name}: slot {slot} claimed by addr 0x{tile_cmd:02X} t={t}s")
+        elif err_type == 0x09:
+            print(f"      {mark}{name}: slot {slot} (addr 0x{tile_cmd:02X}) "
+                  f"mapped but silent t={t}s")
         else:
             print(f"      {mark}slot={slot} tile_cmd=0x{tile_cmd:02X} type={name} t={t}s")
 
@@ -456,7 +480,20 @@ def health_poll(floor: Floor, row: int, last_log: dict[int, list[tuple]]) -> boo
         return False
 
     state = STATUS_STATE_NAMES.get(status[0], hex(status[0]))
-    print(f"    row 0x{row:02X}: state={state} tiles_found={status[1]}")
+    uptime = status_uptime_s(status)
+    up = f" up {fmt_uptime(uptime)}" if uptime is not None else ""
+    print(f"    row 0x{row:02X}: state={state} tiles_found={status[1]}{up}")
+
+    # Uptime going backwards is a reboot, full stop - no inference from log
+    # timestamps needed. Those only move while the row is logging, which on a
+    # healthy row is almost never, so they could never answer this.
+    previous = LAST_UPTIME.get(row)
+    if uptime is not None:
+        if previous is not None and uptime < previous:
+            print(f"    row 0x{row:02X}: REBOOTED since the last poll "
+                  f"(uptime {fmt_uptime(previous)} -> {fmt_uptime(uptime)}) - "
+                  f"read the row_boot entry below for the cause")
+        LAST_UPTIME[row] = uptime
 
     reading = read_power(floor, row)
     if reading is None:

--- a/src/row/include/fw_version.h
+++ b/src/row/include/fw_version.h
@@ -5,4 +5,4 @@
 // A PR touching src/common/tile_bus_protocol bumps this AND
 // src/tile/include/fw_version.h's TILE_FW_VERSION. Plain incrementing
 // integer - gaps are fine, going backwards is not.
-static constexpr uint16_t ROW_FW_VERSION = 2;
+static constexpr uint16_t ROW_FW_VERSION = 3;

--- a/src/row/lib/row_core/row_command_handler.cpp
+++ b/src/row/lib/row_core/row_command_handler.cpp
@@ -38,13 +38,26 @@ void RowCommandHandler::handle_status() {
 
     response_.addr = my_row_addr_;
     response_.cmd  = (uint8_t)RowBusCmd::STATUS_RESP;
-    response_.len  = 10;
+    response_.len  = 14;
     // SenseMapState's declaration order (IDLE, DISCOVERING, DONE, ERROR)
     // already matches the wire's 0x00-0x03 (idle/discovering/running/error).
     response_.payload[0] = (uint8_t)sense_.state();
     response_.payload[1] = map.discovered_count();
     for (uint8_t slot = 0; slot < TileMap::NUM_SLOTS; slot++)
         response_.payload[2 + slot] = (uint8_t)map.status_for(slot);
+
+    // Uptime in seconds, so "did this row restart?" is a number rather than
+    // an inference. The error log's newest timestamp was the only clock the
+    // Pi could see, and it stops advancing the moment the row stops logging -
+    // which on a healthy row is most of the time. 32 bits because a 16-bit
+    // second count wraps at 18.2 hours, and a floor is expected to run longer
+    // than that; a wrap here would read as exactly the reboot it exists to
+    // rule out. Sourced from poll()'s clock, which runs every loop iteration.
+    const uint32_t uptime_s = last_now_ms_ / 1000;
+    response_.payload[10] = (uint8_t)(uptime_s >> 24);
+    response_.payload[11] = (uint8_t)(uptime_s >> 16);
+    response_.payload[12] = (uint8_t)(uptime_s >> 8);
+    response_.payload[13] = (uint8_t)(uptime_s & 0xFF);
 }
 
 void RowCommandHandler::handle_power() {
@@ -73,16 +86,30 @@ void RowCommandHandler::handle_re_discover() {
 void RowCommandHandler::handle_error_log() {
     response_.addr = my_row_addr_;
     response_.cmd  = (uint8_t)RowBusCmd::ERROR_LOG_RESP;
-    response_.len  = (uint16_t)(1 + error_log_count_ * 5);
-    response_.payload[0] = error_log_count_;
+    const uint8_t total = (uint8_t)(error_log_count_ + (has_boot_entry_ ? 1 : 0));
+    response_.len  = (uint16_t)(1 + total * 5);
+    response_.payload[0] = total;
 
-    // Oldest first: if the buffer hasn't wrapped yet, entry 0 is oldest and
-    // sits at index 0; once full, the oldest is whatever error_log_next_ is
-    // about to overwrite.
+    // The boot entry leads, and is also the oldest thing the row can report:
+    // it is written in setup1() before anything else can log.
+    uint8_t out = 0;
+    if (has_boot_entry_) {
+        uint8_t *p = &response_.payload[1];
+        p[0] = boot_entry_.slot;
+        p[1] = boot_entry_.tile_bus_cmd;
+        p[2] = boot_entry_.error_type;
+        p[3] = (uint8_t)(boot_entry_.timestamp_s >> 8);
+        p[4] = (uint8_t)(boot_entry_.timestamp_s & 0xFF);
+        out = 1;
+    }
+
+    // Then the ring, oldest first: if it hasn't wrapped yet, entry 0 is oldest
+    // and sits at index 0; once full, the oldest is whatever error_log_next_
+    // is about to overwrite.
     uint8_t start = (error_log_count_ == ERROR_LOG_CAPACITY) ? error_log_next_ : 0;
     for (uint8_t i = 0; i < error_log_count_; i++) {
         const ErrorLogEntry &e = error_log_[(start + i) % ERROR_LOG_CAPACITY];
-        uint8_t *p = &response_.payload[1 + i * 5];
+        uint8_t *p = &response_.payload[1 + (out + i) * 5];
         p[0] = e.slot;
         p[1] = e.tile_bus_cmd;
         p[2] = e.error_type;
@@ -126,8 +153,15 @@ void RowCommandHandler::log_boot(uint32_t chip_reset_reason, uint32_t now_ms) {
     // Every HAD_* cause bit sits in POWMAN_CHIP_RESET bits 16-28, so the
     // caller's >> 16 leaves them all inside 16 bits - split across the two
     // spare bytes this entry has.
-    log_error((uint8_t)(chip_reset_reason >> 8), (uint8_t)(chip_reset_reason & 0xFF),
-              ERROR_TYPE_ROW_BOOT, now_ms);
+    //
+    // Written outside the ring: this is the only entry whose value grows with
+    // age, since it answers "did this row restart, and why" long after any
+    // fault that followed it has scrolled away.
+    boot_entry_.slot         = (uint8_t)(chip_reset_reason >> 8);
+    boot_entry_.tile_bus_cmd = (uint8_t)(chip_reset_reason & 0xFF);
+    boot_entry_.error_type   = ERROR_TYPE_ROW_BOOT;
+    boot_entry_.timestamp_s  = (uint16_t)(now_ms / 1000);
+    has_boot_entry_          = true;
 }
 
 void RowCommandHandler::log_sense_start(uint32_t now_ms) {
@@ -135,8 +169,8 @@ void RowCommandHandler::log_sense_start(uint32_t now_ms) {
     log_error(sweep_counter++, 0, ERROR_TYPE_SENSE_START, now_ms);
 }
 
-void RowCommandHandler::log_sense_extra_slot(uint8_t slot, uint8_t addr, uint32_t now_ms) {
-    log_error(slot, addr, ERROR_TYPE_SENSE_EXTRA_SLOT, now_ms);
+void RowCommandHandler::log_tile_no_version(uint8_t slot, uint8_t addr, uint32_t now_ms) {
+    log_error(slot, addr, ERROR_TYPE_TILE_NO_VERSION, now_ms);
 }
 
 void RowCommandHandler::log_error(uint8_t slot, uint8_t tile_bus_cmd, uint8_t error_type, uint32_t now_ms) {

--- a/src/row/lib/row_core/row_command_handler.h
+++ b/src/row/lib/row_core/row_command_handler.h
@@ -38,13 +38,16 @@ static constexpr uint8_t ERROR_TYPE_ROW_BUS_RX_OVERFLOW = 0x05;
 // the firmware, and the row was in fact browning out. A plain
 // watchdog_caused_reboot() bool could not have told those apart.
 static constexpr uint8_t ERROR_TYPE_ROW_BOOT = 0x06;
-// Discovery assigned a tile to slot 1 or higher. On a one-tile bench that
-// should never happen, and the row intermittently comes up claiming all 8
-// slots at address 0x01 - but every sense walk captured on the wire has
-// found exactly one tile, so the extra slots are being assigned somewhere
-// the Tile Bus does not show. slot = the slot claimed, tile_bus_cmd = the
-// address it was given.
-static constexpr uint8_t ERROR_TYPE_SENSE_EXTRA_SLOT = 0x07;
+// 0x07 is retired. It used to flag "discovery assigned a tile to slot 1 or
+// higher", which was a usable proxy for the phantom-8 cascade only while the
+// bench had a single tile. Since addresses are assigned by position
+// (SET_ADDRESS), slot 1 holding 0x02 is simply correct, so it fired on every
+// sweep of a healthy two-tile row - twice a second through the boot retry
+// window, filling the ring in 16 seconds and evicting ROW_BOOT, the one entry
+// worth keeping. A diagnostic that destroys the evidence it was added to
+// preserve is worse than none. Deliberately not reused: an older row's 0x07
+// entries decode as unknown on a newer host rather than being mislabelled as
+// a fault that now means something else.
 // One entry each time a discovery sweep begins, slot = a wrapping counter.
 // The error log does not survive a chip reset (it is a plain global, zeroed
 // by static init), so these say whether a restart was a reset at all: sweeps
@@ -53,6 +56,18 @@ static constexpr uint8_t ERROR_TYPE_SENSE_EXTRA_SLOT = 0x07;
 // Reading the counter alongside a bus capture is also what pins the row's
 // millis() epoch to a point on the wire.
 static constexpr uint8_t ERROR_TYPE_SENSE_START = 0x08;
+// A tile that discovery mapped, and that then would not answer VERSION.
+// slot = the slot, tile_bus_cmd = the address it was assigned.
+//
+// This is what 0x07 was reaching for. Because SET_ADDRESS makes a tile
+// abandon its previous address, a row that mistakenly walks one tile into
+// several slots leaves every earlier slot pointing at an address nothing
+// answers to - so the phantom cascade shows up here as "every slot but the
+// last went silent", a signature no correct row can produce. It also catches
+// the plainer cases the row was previously blind to: a tile that took an
+// address and then died, or one unplugged mid-run. The sweep already
+// detected all of this and simply moved on without saying so.
+static constexpr uint8_t ERROR_TYPE_TILE_NO_VERSION = 0x09;
 
 // Dispatches Row Bus commands arriving from the Raspberry Pi
 // (docs/row-bus-protocol.md §5). in.addr must already be filtered by the
@@ -77,15 +92,21 @@ public:
     // the error log - main.cpp carries the flag across.
     void log_row_bus_overflow(uint32_t now_ms);
 
-    // Diagnostics, logged by main.cpp: one per boot, and one per tile
-    // assigned to a slot above 0. Both go in the error log because it is the
-    // only channel that already reaches the Pi with a timestamp attached.
+    // Diagnostics, logged by main.cpp: one per boot, one per discovery
+    // sweep, and one per discovered tile that then would not answer VERSION.
+    // All go in the error log because it is the only channel that already
+    // reaches the Pi with a timestamp attached.
     void log_boot(uint32_t chip_reset_reason, uint32_t now_ms);
-    void log_sense_extra_slot(uint8_t slot, uint8_t addr, uint32_t now_ms);
+    void log_tile_no_version(uint8_t slot, uint8_t addr, uint32_t now_ms);
     void log_sense_start(uint32_t now_ms);
 
 private:
-    static constexpr uint8_t ERROR_LOG_CAPACITY = 32;
+    // The boot entry is held outside the ring, so a busy row cannot evict the
+    // one entry that says why it restarted - which is exactly what happened
+    // when two per-sweep diagnostics filled 32 slots in 16 seconds. The ring
+    // is one shorter to keep the response at the documented 161-byte
+    // maximum: 1 + 32 x 5, boot included.
+    static constexpr uint8_t ERROR_LOG_CAPACITY = 31;
 
     void handle_test();
     void handle_status();
@@ -130,4 +151,6 @@ private:
     ErrorLogEntry error_log_[ERROR_LOG_CAPACITY]{};
     uint8_t       error_log_count_ = 0; // valid entries, caps at ERROR_LOG_CAPACITY
     uint8_t       error_log_next_  = 0; // next write index, wraps
+    ErrorLogEntry boot_entry_      = {}; // outside the ring; see ERROR_LOG_CAPACITY
+    bool          has_boot_entry_  = false;
 };

--- a/src/row/lib/row_core/sense_mapper.cpp
+++ b/src/row/lib/row_core/sense_mapper.cpp
@@ -98,11 +98,11 @@ bool SenseMapper::take_sweep_started() {
     return true;
 }
 
-bool SenseMapper::take_extra_slot(uint8_t *slot_out, uint8_t *addr_out) {
-    if (!extra_slot_pending_) return false;
-    extra_slot_pending_ = false;
-    *slot_out = extra_slot_;
-    *addr_out = extra_slot_addr_;
+bool SenseMapper::take_silent_tile(uint8_t *slot_out, uint8_t *addr_out) {
+    if (!silent_tile_pending_) return false;
+    silent_tile_pending_ = false;
+    *slot_out = silent_tile_slot_;
+    *addr_out = silent_tile_addr_;
     return true;
 }
 
@@ -188,11 +188,6 @@ void SenseMapper::poll(uint32_t now_ms) {
             // something replied.
             if (f.cmd == SET_ADDRESS_ACK && f.addr == assigned) {
                 map_.set_discovered(current_slot_, assigned);
-                if (current_slot_ > 0) {
-                    extra_slot_pending_ = true;
-                    extra_slot_        = current_slot_;
-                    extra_slot_addr_   = assigned;
-                }
                 send_activate_sense(assigned);
                 request_sent_ms_ = now_ms;
                 step_ = Step::WAIT_ACTIVATE_ACK;
@@ -254,6 +249,16 @@ void SenseMapper::poll(uint32_t now_ms) {
                 // Discovered but not answering VERSION - leave its cache
                 // entry invalid and move on. Not a discovery fault: the
                 // tile passed SENSE mapping, so its TileStatus stays OK.
+                //
+                // Reported all the same. A tile that took an address and
+                // then went quiet is exactly the condition nothing else
+                // here surfaces, and it is also how a mis-walked row shows
+                // itself: SET_ADDRESS makes a tile drop its old address, so
+                // one tile walked into several slots leaves every slot but
+                // the last answering to nothing.
+                silent_tile_pending_ = true;
+                silent_tile_slot_    = version_slot_;
+                silent_tile_addr_    = map_.address_for(version_slot_);
                 version_slot_++;
                 advance_version_query(now_ms);
             } else {

--- a/src/row/lib/row_core/sense_mapper.h
+++ b/src/row/lib/row_core/sense_mapper.h
@@ -19,14 +19,15 @@ public:
     SenseMapState state() const { return state_; }
     const TileMap &result() const { return map_; }
 
-    // Diagnostic hand-off: reports the most recent tile assigned to a slot
-    // above 0, so main.cpp can put it in the error log (SenseMapper has no
-    // access to that). Returns false when there is nothing pending.
+    // Diagnostic hand-off: reports a slot that discovery mapped and that then
+    // would not answer VERSION, so main.cpp can put it in the error log
+    // (SenseMapper has no access to that). Returns false when nothing is
+    // pending.
     //
-    // A single pending slot is enough: assigning one costs at least a
-    // SETTLE_MS wait plus a Tile Bus round trip, so main.cpp always drains
-    // this before the next one can be recorded.
-    bool take_extra_slot(uint8_t *slot_out, uint8_t *addr_out);
+    // A single pending slot is enough: reaching the next one costs a full
+    // VERSION retry budget of Tile Bus round trips, so main.cpp always drains
+    // this before another can be recorded.
+    bool take_silent_tile(uint8_t *slot_out, uint8_t *addr_out);
 
     // Same hand-off for "a sweep just began". Reported here rather than at
     // each start() call site so no caller can forget it - start() is invoked
@@ -84,7 +85,7 @@ private:
     uint8_t          version_slot_         = 0;
     uint8_t          version_retry_count_  = 0;
     bool             sweep_started_pending_ = false;
-    bool             extra_slot_pending_   = false;
-    uint8_t          extra_slot_           = 0;
-    uint8_t          extra_slot_addr_      = 0;
+    bool             silent_tile_pending_  = false;
+    uint8_t          silent_tile_slot_     = 0;
+    uint8_t          silent_tile_addr_     = 0;
 };

--- a/src/row/src/main.cpp
+++ b/src/row/src/main.cpp
@@ -325,15 +325,15 @@ void loop1() {
 
     sense_mapper.poll(millis());
 
-    // Any tile assigned to a slot above 0 goes in the error log. On a
-    // one-tile bench this should never fire; when the row comes up claiming
-    // 8 tiles, this is what says which slots were claimed and when.
     if (sense_mapper.take_sweep_started())
         row_cmd_handler.log_sense_start(millis());
 
-    uint8_t extra_slot, extra_addr;
-    if (sense_mapper.take_extra_slot(&extra_slot, &extra_addr))
-        row_cmd_handler.log_sense_extra_slot(extra_slot, extra_addr, millis());
+    // A tile discovery mapped that then would not answer VERSION. On a
+    // healthy row this never fires; when the row mis-walks one tile into
+    // several slots, every slot but the last lands here.
+    uint8_t silent_slot, silent_addr;
+    if (sense_mapper.take_silent_tile(&silent_slot, &silent_addr))
+        row_cmd_handler.log_tile_no_version(silent_slot, silent_addr, millis());
 
     drive_ready_led(millis(), sense_mapper.state());
 

--- a/src/row/test/test_row_command_handler/test_row_command_handler.cpp
+++ b/src/row/test/test_row_command_handler/test_row_command_handler.cpp
@@ -66,7 +66,7 @@ void test_status_reports_discovered_tiles_and_state() {
 
     TEST_ASSERT_NOT_NULL(resp);
     TEST_ASSERT_EQUAL_HEX8((uint8_t)RowBusCmd::STATUS_RESP, resp->cmd);
-    TEST_ASSERT_EQUAL(10, resp->len);
+    TEST_ASSERT_EQUAL(14, resp->len);
     TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[0]); // state: IDLE (discovery never started)
     TEST_ASSERT_EQUAL(5, resp->payload[1]);          // tiles_found
     for (uint8_t i = 0; i < 5; i++)
@@ -319,7 +319,7 @@ void test_latch_without_forwarding_is_unaffected_by_overrun_logic() {
     TEST_ASSERT_EQUAL(0, log_resp->payload[0]); // no overrun logged
 }
 
-void test_error_log_ring_buffer_caps_at_32_and_drops_oldest() {
+void test_error_log_ring_buffer_caps_at_31_and_drops_oldest() {
     FakeTileTransport transport;
     FakeRowSense      row_sense;
     TileMap           map;
@@ -338,9 +338,10 @@ void test_error_log_ring_buffer_caps_at_32_and_drops_oldest() {
     RowBusFrame send_req  = make_frame(0x00, RowBusCmd::SEND_DATA, payload, offset);
     RowBusFrame latch_req = make_frame(ROWBUS_ADDR_BROADCAST, RowBusCmd::LATCH, nullptr, 0);
 
-    // Trigger 33 overruns (one more than the 32-entry capacity), each with a
-    // distinct timestamp, to verify the oldest entry gets dropped.
-    for (uint32_t i = 0; i < 33; i++) {
+    // Trigger 32 overruns (one more than the 31-entry ring), each with a
+    // distinct timestamp, to verify the oldest entry gets dropped. The ring is
+    // 31 rather than 32 because the boot entry is held outside it.
+    for (uint32_t i = 0; i < 32; i++) {
         uint32_t now_ms = i * 1000;
         handler.handle(send_req);
         handler.poll(now_ms);                            // advance 1 slot, then defer
@@ -350,15 +351,104 @@ void test_error_log_ring_buffer_caps_at_32_and_drops_oldest() {
 
     RowBusFrame log_req = make_frame(0x00, RowBusCmd::ERROR_LOG, nullptr, 0);
     const RowBusFrame *resp = handler.handle(log_req);
-    TEST_ASSERT_EQUAL(32, resp->payload[0]);
-    TEST_ASSERT_EQUAL(1 + 32 * 5, resp->len);
+    TEST_ASSERT_EQUAL(31, resp->payload[0]);
+    TEST_ASSERT_EQUAL(1 + 31 * 5, resp->len);
 
     // Oldest (timestamp 0, from i=0) was overwritten; entries are timestamps
-    // 1..32, oldest first.
-    for (int i = 0; i < 32; i++) {
+    // 1..31, oldest first.
+    for (int i = 0; i < 31; i++) {
         uint16_t ts = (uint16_t)((resp->payload[1 + i * 5 + 3] << 8) | resp->payload[1 + i * 5 + 4]);
         TEST_ASSERT_EQUAL(i + 1, ts);
     }
+}
+
+// Uptime is what makes "did this row restart?" answerable. Before it, the only
+// clock the Pi could see was the newest error-log timestamp, which stops
+// advancing whenever the row stops logging - i.e. whenever it is healthy.
+void test_status_reports_uptime_from_poll_clock() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+    RowCommandHandler handler(transport, sense, power, 0x00);
+
+    handler.poll(3661000);  // 1h 1m 1s
+    RowBusFrame req = make_frame(0x00, RowBusCmd::STATUS, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NOT_NULL(resp);
+    uint32_t uptime = ((uint32_t)resp->payload[10] << 24) | ((uint32_t)resp->payload[11] << 16) |
+                      ((uint32_t)resp->payload[12] << 8)  | resp->payload[13];
+    TEST_ASSERT_EQUAL_UINT32(3661, uptime);
+}
+
+// 32 bits, not 16: a 16-bit second count wraps at 18.2 hours, and a wrap would
+// read as exactly the reboot this field exists to rule out.
+void test_status_uptime_survives_past_16_bit_seconds() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+    RowCommandHandler handler(transport, sense, power, 0x00);
+
+    handler.poll(200000000);  // ~55 hours, well past a uint16 of seconds
+    RowBusFrame req = make_frame(0x00, RowBusCmd::STATUS, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    uint32_t uptime = ((uint32_t)resp->payload[10] << 24) | ((uint32_t)resp->payload[11] << 16) |
+                      ((uint32_t)resp->payload[12] << 8)  | resp->payload[13];
+    TEST_ASSERT_EQUAL_UINT32(200000, uptime);
+}
+
+// The boot entry is the one whose value grows with age, so it must outlive a
+// full ring. Two per-sweep diagnostics once flooded 32 slots in 16 seconds and
+// evicted it - which is why it now lives outside the ring entirely.
+void test_boot_entry_survives_a_full_ring_and_reports_first() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+    RowCommandHandler handler(transport, sense, power, 0x00);
+
+    handler.log_boot(0x0002, 0);  // brownout
+
+    // Flood well past the ring's capacity with unrelated entries.
+    for (uint32_t i = 1; i <= 60; i++) handler.log_sense_start(i * 1000);
+
+    RowBusFrame req = make_frame(0x00, RowBusCmd::ERROR_LOG, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_NOT_NULL(resp);
+    TEST_ASSERT_EQUAL(32, resp->payload[0]);           // 31 ring + 1 boot
+    TEST_ASSERT_EQUAL(1 + 32 * 5, resp->len);          // still the documented max
+    TEST_ASSERT_EQUAL_HEX8(ERROR_TYPE_ROW_BOOT, resp->payload[1 + 2]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, resp->payload[1 + 0]); // cause hi
+    TEST_ASSERT_EQUAL_HEX8(0x02, resp->payload[1 + 1]); // cause lo: brownout
+    // and the entries after it are the ring, not another copy of boot
+    TEST_ASSERT_EQUAL_HEX8(ERROR_TYPE_SENSE_START, resp->payload[1 + 5 + 2]);
+}
+
+void test_tile_no_version_records_slot_and_address() {
+    FakeTileTransport transport;
+    FakeRowSense      row_sense;
+    TileMap           map;
+    SenseMapper       sense(transport, row_sense, map);
+    FakePowerMonitor  power;
+    RowCommandHandler handler(transport, sense, power, 0x00);
+
+    handler.log_tile_no_version(3, 0x04, 12000);
+
+    RowBusFrame req = make_frame(0x00, RowBusCmd::ERROR_LOG, nullptr, 0);
+    const RowBusFrame *resp = handler.handle(req);
+
+    TEST_ASSERT_EQUAL(1, resp->payload[0]);
+    TEST_ASSERT_EQUAL_HEX8(3, resp->payload[1 + 0]);
+    TEST_ASSERT_EQUAL_HEX8(0x04, resp->payload[1 + 1]);
+    TEST_ASSERT_EQUAL_HEX8(ERROR_TYPE_TILE_NO_VERSION, resp->payload[1 + 2]);
+    TEST_ASSERT_EQUAL(12, (resp->payload[1 + 3] << 8) | resp->payload[1 + 4]);
 }
 
 // ---------------------------------------------------------------------------
@@ -548,7 +638,11 @@ int main(int, char **) {
     RUN_TEST(test_latch_broadcasts_tile_latch);
     RUN_TEST(test_latch_defers_when_send_data_still_forwarding);
     RUN_TEST(test_latch_without_forwarding_is_unaffected_by_overrun_logic);
-    RUN_TEST(test_error_log_ring_buffer_caps_at_32_and_drops_oldest);
+    RUN_TEST(test_error_log_ring_buffer_caps_at_31_and_drops_oldest);
+    RUN_TEST(test_status_reports_uptime_from_poll_clock);
+    RUN_TEST(test_status_uptime_survives_past_16_bit_seconds);
+    RUN_TEST(test_boot_entry_survives_a_full_ring_and_reports_first);
+    RUN_TEST(test_tile_no_version_records_slot_and_address);
     RUN_TEST(test_blackout_sends_black_to_each_discovered_tile_then_latch);
     RUN_TEST(test_re_discover_starts_sense_mapping_and_acks);
     RUN_TEST(test_test_command_returns_always_pass_stub);


### PR DESCRIPTION
Three changes that make a row's account of itself trustworthy. All three came out of one bench failure last week: the row rebooted, the tiles held their last frame, and nothing in any log said so. Diagnosing it took hours and ended in inference rather than evidence.

## 1. `STATUS_RESP` reports uptime

*"Did this row restart?"* had no direct answer. The only clock the Pi could see was the newest `ERROR_LOG` timestamp — which advances **only while the row is logging**, i.e. almost never on a healthy row. A stale clock and a steady one were indistinguishable.

This run, on the reflashed hardware, is the whole argument:

```
up 2m07s   ...   row clock >= 19s; all predate this run
up 2m17s   ...   row clock >= 19s; 0 new since last poll - all stale
up 2m26s   ...   row clock >= 19s; 0 new since last poll - all stale
```

Real uptime tracks the 9-second poll interval. The old signal sits frozen at 19 s because the row went quiet when its boot window closed. On the old firmware a row up for 19 seconds and one up for two and a half minutes looked identical — which is exactly why last week's reboot had to be deduced from `tiles_found=0` instead of read off a field.

`uptime_s` is **uint32**, not uint16: a 16-bit second count wraps at 18.2 hours, a floor is expected to run longer than that, and a wrap would read as precisely the reboot the field exists to rule out.

## 2. `ROW_BOOT` moved outside the ring buffer

It is the one entry whose value *grows* with age — it answers "why did this row restart" long after any fault that followed has scrolled away. It was being evicted **16 seconds after boot**.

Now stored separately and always reported first. The ring drops to 31 so the response keeps its documented 161-byte maximum.

## 3. `0x07 SENSE_EXTRA_SLOT` retired, `0x09 TILE_NO_VERSION` added

`0x07` flagged *"discovery assigned a tile to slot 1 or higher"*. That was a usable proxy for the phantom-8 cascade only while the bench had a single tile. Since [#73](https://github.com/tennessee-garage/dance-more/pull/73) assigns addresses by position, **slot 1 holding `0x02` is simply correct** — so it fired on every sweep of a healthy two-tile row, twice a second through the boot retry window. That is what filled the ring and evicted `ROW_BOOT`.

A diagnostic that destroys the evidence it was added to preserve is worse than none.

`0x09` is what `0x07` was reaching for. The post-discovery `VERSION` sweep **already** detected tiles that were mapped and then went silent, and moved on without saying so. Because `SET_ADDRESS` makes a tile abandon its previous address, a row that mis-walks one tile into several slots leaves every slot but the last answering to nothing — so the cascade appears here as *"every slot but the last went silent"*, a signature no correct row can produce. It also catches what the row was simply blind to: a tile that took an address and then died, or one unplugged mid-run.

The code is **deliberately not reused**, so an older row's `0x07` entries decode as unknown rather than being mislabelled as a different fault.

## Verified on hardware

Row reflashed (`VERSION row fw = 3`), one row, two tiles:

| | Before | After |
| --- | --- | --- |
| STATUS payload | 10 bytes, no uptime | **14 bytes, `up 2m26s`** |
| First log entry | `sense_start` — `ROW_BOOT` evicted | **`row_boot: power-on`, protected** |
| Log contents | 32 entries, all sweep noise | **21 entries**, 11 slots free for real faults |
| Retired `0x07` | 16 false positives | **none** |

`tile_no_version` correctly stayed silent on a healthy row.

**Backward compatibility was tested against the old firmware before the reflash**, not assumed: the host printed `unknown(0x07)` and omitted the uptime field, exactly as intended. A `STATUS` payload shorter than 14 bytes is treated as older firmware rather than a malformed reply, so the host runs against both.

## Testing

- 62 row unit tests (up from 55 — new coverage for uptime, the 32-bit range, boot-entry survival across a full ring, and `tile_no_version`)
- 72 host tests
- `pio run -e row0` builds; `ROW_FW_VERSION` 2 → 3

Firmware, host and docs are in separate commits per the repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
